### PR TITLE
Max players

### DIFF
--- a/src/hub.rs
+++ b/src/hub.rs
@@ -3,21 +3,22 @@
 //! When a WsMessage comes in from a WsGameSession, the GameHub routes the message to the proper Game
 
 //! This file is adapted from the actix-web chat websocket example
- 
+
 use std::{
-    thread,
     collections::{HashMap, HashSet, VecDeque},
     sync::{atomic::AtomicUsize, Arc, Mutex},
 };
 
-use crate::messages::{WsMessage, MetaAction, MetaActionMessage, Connect, Create, CreateGameError,
-		      Join, Removed, ListTables, PlayerName, PlayerActionMessage};
-use crate::logic::{Game, PlayerConfig, PlayerAction};
-use actix::AsyncContext;
+use crate::logic::{Game, PlayerAction, PlayerConfig};
+use crate::messages::{
+    Connect, Create, CreateGameError, Join, ListTables, MetaAction, MetaActionMessage,
+    PlayerActionMessage, PlayerName, Removed, WsMessage,
+};
 use actix::prelude::{Actor, Context, Handler, MessageResult};
-use uuid::Uuid;
-use rand::Rng;
+use actix::AsyncContext;
 use json::object;
+use rand::Rng;
+use uuid::Uuid;
 
 // for generator random game names
 const CHAR_SET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -33,12 +34,12 @@ pub struct GameHub {
     players_to_table: HashMap<Uuid, String>,
 
     // this is where the hub can add incoming player actions for a running game to grab from
-    tables_to_actions: HashMap<String, Arc<Mutex<HashMap<Uuid, PlayerAction>>>>,
+    tables_to_actions: HashMap<String, Mutex<HashMap<Uuid, PlayerAction>>>,
 
-    tables_to_meta_actions: HashMap<String, Arc<Mutex<VecDeque<MetaAction>>>>,        
+    tables_to_meta_actions: HashMap<String, Mutex<VecDeque<MetaAction>>>,
 
     private_tables: HashSet<String>, // which games do not show up in the loby
-    
+
     visitor_count: Arc<AtomicUsize>,
 }
 
@@ -49,9 +50,9 @@ impl GameHub {
             //tables_to_session_ids: HashMap::new(),
             main_lobby_connections: HashMap::new(),
             players_to_table: HashMap::new(),
-	    tables_to_actions: HashMap::new(),
-	    tables_to_meta_actions: HashMap::new(),
-	    private_tables: HashSet::new(),
+            tables_to_actions: HashMap::new(),
+            tables_to_meta_actions: HashMap::new(),
+            private_tables: HashSet::new(),
             visitor_count,
         }
     }
@@ -77,9 +78,9 @@ impl Handler<Connect> for GameHub {
         let id = uuid::Uuid::new_v4();
         // create a config with name==None to start
         let player_config = PlayerConfig::new(id, None, Some(msg.addr));
-	
-	// put them in the main lobby to wait to join a table
-        self.main_lobby_connections.insert(id, player_config); 
+
+        // put them in the main lobby to wait to join a table
+        self.main_lobby_connections.insert(id, player_config);
 
         // send id back
         MessageResult(id)
@@ -94,10 +95,10 @@ impl Handler<ListTables> for GameHub {
         let mut tables = Vec::new();
 
         for key in self.tables_to_actions.keys() {
-	    if self.private_tables.contains(key) {
-		// don't return private tables
-		continue;
-	    }
+            if self.private_tables.contains(key) {
+                // don't return private tables
+                continue;
+            }
             tables.push(key.to_owned())
         }
 
@@ -112,30 +113,37 @@ impl Handler<PlayerName> for GameHub {
     fn handle(&mut self, msg: PlayerName, _: &mut Context<Self>) {
         // if the player is the main lobby, find them and set their name
         if let Some(player_config) = self.main_lobby_connections.get_mut(&msg.id) {
-	    println!("setting player name in the main lobby");
-	    let message = object!{
-		msg_type: "name_changed".to_owned(),
-		new_name: msg.name.clone(),
-	    };	    
-            player_config.player_addr.as_ref().unwrap()
-		.do_send(
-		    WsMessage(message.dump())
-		);	    
+            println!("setting player name in the main lobby");
+            let message = object! {
+            msg_type: "name_changed".to_owned(),
+            new_name: msg.name.clone(),
+            };
+            player_config
+                .player_addr
+                .as_ref()
+                .unwrap()
+                .do_send(WsMessage(message.dump()));
             player_config.name = Some(msg.name);
         } else if let Some(table_name) = self.players_to_table.get(&msg.id) {
             // otherwise, find which game they are in, and tell the game there has been a name change
             if let Some(meta_actions) = self.tables_to_meta_actions.get_mut(table_name) {
-		println!("passing player name to the game");
-		meta_actions.lock().unwrap().push_back(MetaAction::PlayerName(msg.id, msg.name));
-		println!("meta actions = {:?}", meta_actions);		
+                println!("passing player name to the game");
+                meta_actions
+                    .lock()
+                    .unwrap()
+                    .push_back(MetaAction::PlayerName(msg.id, msg.name));
+                println!("meta actions = {:?}", meta_actions);
             } else {
                 // TODO: this should never happen. the player is allegedly at a table, but we
                 // have no record of it in tables_to_meta_actions
-		panic!("we can not find the meta actions for table named {:?}", table_name);
+                panic!(
+                    "we can not find the meta actions for table named {:?}",
+                    table_name
+                );
             }
         } else {
             // player id not found anywhere. this should never happen
-	    panic!("how can we set a name if no config exists anywhere!");	    
+            panic!("how can we set a name if no config exists anywhere!");
         }
     }
 }
@@ -147,44 +155,55 @@ impl Handler<Join> for GameHub {
 
     fn handle(&mut self, msg: Join, _: &mut Context<Self>) {
         let Join { id, table_name } = msg;
-	
+
         let player_config_option = self.main_lobby_connections.remove(&id);
-	if player_config_option.is_none() {
-	    // the player is not in the main lobby,
-	    // so we must be waiting for the game to remove the player still
-	    println!("player config not in the main lobby, so they must already be at a game");
-	    return;
-	} 
-	let player_config = player_config_option.unwrap();		
+        if player_config_option.is_none() {
+            // the player is not in the main lobby,
+            // so we must be waiting for the game to remove the player still
+            println!("player config not in the main lobby, so they must already be at a game");
+            return;
+        }
+        let player_config = player_config_option.unwrap();
 
-	if player_config.name.is_none() {
-	    // they are not allowed to join a game without a Name set
-            player_config.player_addr.as_ref().unwrap()
-		.do_send(
-		    WsMessage(format!("You cannot join a game until you set your name!"))
-		);
-	    // put them back in the lobby
-	    self.main_lobby_connections.insert(player_config.id, player_config);
-	    return
-	}
+        if player_config.name.is_none() {
+            // they are not allowed to join a game without a Name set
+            player_config
+                .player_addr
+                .as_ref()
+                .unwrap()
+                .do_send(WsMessage(format!(
+                    "You cannot join a game until you set your name!"
+                )));
+            // put them back in the lobby
+            self.main_lobby_connections
+                .insert(player_config.id, player_config);
+            return;
+        }
 
-        // update the mapping to find the player at a table	
+        // update the mapping to find the player at a table
         self.players_to_table.insert(id, table_name.clone());
 
         if let Some(meta_actions) = self.tables_to_meta_actions.get_mut(&table_name) {
-	    // since the meta actions already exist, this means the game already exists
-	    // so we can simply join it
-	    println!("joining existing game!");
-	    meta_actions.lock().unwrap().push_back(MetaAction::Join(player_config));
+            // since the meta actions already exist, this means the game already exists
+            // so we can simply join it
+            println!("joining existing game!");
+            meta_actions
+                .lock()
+                .unwrap()
+                .push_back(MetaAction::Join(player_config));
         } else {
-            player_config.player_addr.as_ref().unwrap()
-		.do_send(
-		    WsMessage(format!("No table with that name exists to join!"))
-		);
-	    // put them back in the lobby
-	    self.main_lobby_connections.insert(player_config.id, player_config);
-	}
-    }    
+            player_config
+                .player_addr
+                .as_ref()
+                .unwrap()
+                .do_send(WsMessage(format!(
+                    "No table with that name exists to join!"
+                )));
+            // put them back in the lobby
+            self.main_lobby_connections
+                .insert(player_config.id, player_config);
+        }
+    }
 }
 
 /// Handler for a player that has been removed from a game officially
@@ -193,23 +212,26 @@ impl Handler<Removed> for GameHub {
     type Result = ();
 
     fn handle(&mut self, msg: Removed, _: &mut Context<Self>) {
-	println!("Handling player {:?} removed", msg.config);	
+        println!("Handling player {:?} removed", msg.config);
         if let Some(table_name) = self.players_to_table.remove(&msg.config.id) {
-	    // we stil think this player is at table in our mapping, so remove it
-	    println!("removing player {:?} removed from {:?}", msg.config, table_name);
-	}
-	// add the config back into the lobby
+            // we stil think this player is at table in our mapping, so remove it
+            println!(
+                "removing player {:?} removed from {:?}",
+                msg.config, table_name
+            );
+        }
+        // add the config back into the lobby
         if let Some(addr) = &msg.config.player_addr {
-	    let message = object!{
-		msg_type: "left_game".to_owned(),
-	    };	    
+            let message = object! {
+            msg_type: "left_game".to_owned(),
+            };
             addr.do_send(WsMessage(message.dump()));
         }
-	
-	self.main_lobby_connections.insert(msg.config.id, msg.config);
+
+        self.main_lobby_connections
+            .insert(msg.config.id, msg.config);
     }
 }
-
 
 /// create table, cannot already be at a table
 impl Handler<Create> for GameHub {
@@ -218,134 +240,142 @@ impl Handler<Create> for GameHub {
     /// creates a game and returns either Ok(table_name) or an Er(CreateGameError)
     /// if the player is not in the lobby or does not have their name set
     fn handle(&mut self, msg: Create, ctx: &mut Context<Self>) -> Self::Result {
-        let Create { id, create_msg } = msg;	    
-	
+        let Create { id, create_msg } = msg;
+
         let player_config_option = self.main_lobby_connections.remove(&id);
-	if player_config_option.is_none() {
-	    // the player is not in the main lobby,
-	    // so we must be waiting for the game to remove the player still
-	    println!("player config not in the main lobby, so they must already be at a game");
-	    return Err(CreateGameError::AlreadyAtTable("todo".to_owned()));
-	} 
-	let player_config = player_config_option.unwrap();		
+        if player_config_option.is_none() {
+            // the player is not in the main lobby,
+            // so we must be waiting for the game to remove the player still
+            println!("player config not in the main lobby, so they must already be at a game");
+            return Err(CreateGameError::AlreadyAtTable("todo".to_owned()));
+        }
+        let player_config = player_config_option.unwrap();
 
-	if player_config.name.is_none() {
-	    // they are not allowed to join a game without a Name set
-	    // put them back in the lobby
-	    self.main_lobby_connections.insert(player_config.id, player_config);
-	    return Err(CreateGameError::NameNotSet);	    	    
-	}
+        if player_config.name.is_none() {
+            // they are not allowed to join a game without a Name set
+            // put them back in the lobby
+            self.main_lobby_connections
+                .insert(player_config.id, player_config);
+            return Err(CreateGameError::NameNotSet);
+        }
 
+        if let (
+            Some(max_players),
+            Some(small_blind),
+            Some(big_blind),
+            Some(buy_in),
+            Some(num_bots),
+            Some(is_private),
+            Some(password),
+        ) = (
+            create_msg.get("max_players"),
+            create_msg.get("small_blind"),
+            create_msg.get("big_blind"),
+            create_msg.get("buy_in"),
+            create_msg.get("num_bots"),
+            create_msg.get("is_private"),
+            create_msg.get("password"),
+        ) {
+            let max_players = max_players
+                .to_string()
+                .parse::<u8>()
+                .map_err(|_| CreateGameError::InvalidFieldValue("max_players".to_owned()))?;
+            let small_blind = small_blind
+                .to_string()
+                .parse::<u32>()
+                .map_err(|_| CreateGameError::InvalidFieldValue("small_blind".to_owned()))?;
+            let big_blind = big_blind
+                .to_string()
+                .parse::<u32>()
+                .map_err(|_| CreateGameError::InvalidFieldValue("big_blind".to_owned()))?;
+            let buy_in = buy_in
+                .to_string()
+                .parse::<u32>()
+                .map_err(|_| CreateGameError::InvalidFieldValue("buy_in".to_owned()))?;
+            let num_bots = num_bots
+                .to_string()
+                .parse::<u8>()
+                .map_err(|_| CreateGameError::InvalidFieldValue("num_bots".to_owned()))?;
+            let is_private = is_private
+                .to_string()
+                .parse::<bool>()
+                .map_err(|_| CreateGameError::InvalidFieldValue("is_private".to_owned()))?;
 
-	if let (Some(max_players),
-		Some(small_blind),
-		Some(big_blind),
-		Some(buy_in),
-		Some(num_bots),					     
-		Some(is_private),
-		Some(password)) = (create_msg.get("max_players"),
-				   create_msg.get("small_blind"),
-				   create_msg.get("big_blind"),
-				   create_msg.get("buy_in"),
-				   create_msg.get("num_bots"),
-				   create_msg.get("is_private"),
-				   create_msg.get("password")) 	{
-	    let max_players = max_players.to_string()
-		.parse::<u8>()
-		.map_err(|_| CreateGameError::InvalidFieldValue("max_players".to_owned()))?;
-	    let small_blind = small_blind.to_string()
-		.parse::<u32>()
-		.map_err(|_| CreateGameError::InvalidFieldValue("small_blind".to_owned()))?;
-	    let big_blind = big_blind.to_string()
-		.parse::<u32>()
-		.map_err(|_| CreateGameError::InvalidFieldValue("big_blind".to_owned()))?;
-	    let buy_in = buy_in.to_string()
-		.parse::<u32>()
-		.map_err(|_| CreateGameError::InvalidFieldValue("buy_in".to_owned()))?;
-	    let num_bots = num_bots.to_string()
-		.parse::<u8>()
-		.map_err(|_| CreateGameError::InvalidFieldValue("num_bots".to_owned()))?;
-	    let is_private = is_private.to_string()
-		.parse::<bool>()
-		.map_err(|_| CreateGameError::InvalidFieldValue("is_private".to_owned()))?;
+            println!("password in create game = {:?}", password);
 
-	    println!("password in create game = {:?}", password);	    
+            let password = if password.is_string() {
+                Some(password.to_string())
+            } else {
+                None
+            };
 
-	    let password = if password.is_string() {
-		Some(password.to_string())
-	    } else {
-		None
-	    };
+            let mut rng = rand::thread_rng();
+            let table_name = loop {
+                // create a new 4-char unique name for the table
+                let genned_name: String = (0..GAME_NAME_LEN)
+                    .map(|_| {
+                        let idx = rng.gen_range(0..CHAR_SET.len());
+                        CHAR_SET[idx] as char
+                    })
+                    .collect();
+                if self.tables_to_actions.contains_key(&genned_name) {
+                    // unlikely, but we already have a table with this exact name
+                    continue;
+                }
+                // we genned a name that is new
+                break genned_name;
+            };
 
-	    let mut rng = rand::thread_rng();	
-	    let table_name = loop {
-		// create a new 4-char unique name for the table
-		let genned_name: String = (0..GAME_NAME_LEN)
-		    .map(|_| {
-			let idx = rng.gen_range(0..CHAR_SET.len());
-			CHAR_SET[idx] as char
-		    })
-		    .collect();
-		if self.tables_to_actions.contains_key(&genned_name) {
-		    // unlikely, but we already have a table with this exact name
-		    continue;
-		}
-		// we genned a name that is new
-		break genned_name
-	    };
-
-
-	    let actions = Arc::new(Mutex::new(HashMap::new()));	
-	    let cloned_actions = actions.clone();
-	    
-	    let meta_actions = Arc::new(Mutex::new(VecDeque::new()));
-	    let cloned_meta_actions = meta_actions.clone();
+            let actions = Mutex::new(HashMap::new());
+            let meta_actions = Mutex::new(VecDeque::new());
 
             let mut game = Game::new(
-		ctx.address(),
-		&cloned_actions,
-		&cloned_meta_actions,		
-		table_name.clone(),
-		None, // no deck needed to pass in
-		max_players,
-		small_blind,
-		big_blind,
-		buy_in,
-		is_private, // TODO does the game even need this field
-		password,
-	    );
+                ctx.address(),
+                &actions,
+                &meta_actions,
+                table_name.clone(),
+                None, // no deck needed to pass in
+                max_players,
+                small_blind,
+                big_blind,
+                buy_in,
+                is_private, // TODO does the game even need this field
+                password,
+            );
 
             for i in 0..num_bots {
-		let name = format!("Mr {}", i);
-		game.add_bot(name);
+                let name = format!("Mr {}", i);
+                game.add_bot(name);
             }
 
-	    if is_private {
-		self.private_tables.insert(table_name.clone());
-	    }
-	    
-            // update the mapping to find the player at a table	
+            if is_private {
+                self.private_tables.insert(table_name.clone());
+            }
+
+            // update the mapping to find the player at a table
             self.players_to_table.insert(id, table_name.clone());
 
             if game.add_user(player_config).is_none() {
-		panic!("how were we unable to join a fresh game?");
-	    } else {
-		println!("in the hub. we just joined fine?");
-	    }
-	    
-	    //let b: bool = cloned_queue;
-	    thread::spawn(move || {
-		// start a game with no hand limit
-		game.play(None);
-	    });
-	    
+                panic!("how were we unable to join a fresh game?");
+            } else {
+                println!("in the hub. we just joined fine?");
+            }
+
+            std::thread::scope(|scope| {
+                // need to use scoped thread here so that the actions don't need static life time
+                scope.spawn(move || {
+                    game.play(None);
+                });
+            });
+
             self.tables_to_actions.insert(table_name.clone(), actions);
-            self.tables_to_meta_actions.insert(table_name.clone(), meta_actions);
-            Ok(table_name) // return the table name	    
-	} else {
-	    println!("create message missing one or more required fields!");
-	    return Err(CreateGameError::MissingField);
-	}
+            self.tables_to_meta_actions
+                .insert(table_name.clone(), meta_actions);
+            Ok(table_name) // return the table name
+        } else {
+            println!("create message missing one or more required fields!");
+            return Err(CreateGameError::MissingField);
+        }
     }
 }
 
@@ -359,17 +389,19 @@ impl Handler<PlayerActionMessage> for GameHub {
         if let Some(table_name) = self.players_to_table.get(&msg.id) {
             // the player was at a table, so tell the Game this player's message
             if let Some(actions_map) = self.tables_to_actions.get_mut(table_name) {
-		println!("handling player action in the hub!");
-		actions_map.lock().unwrap().insert(msg.id, msg.player_action);
-		println!("actions map = {:?}", actions_map);		
+                println!("handling player action in the hub!");
+                actions_map
+                    .lock()
+                    .unwrap()
+                    .insert(msg.id, msg.player_action);
+                println!("actions map = {:?}", actions_map);
             } else {
                 // TODO: this should never happen. the player is allegedly at a table, but we
                 // have no record of it in tables_to_game
-		println!("blah blah mp actioms queue!");
+                println!("blah blah mp actioms queue!");
             }
-
         }
-    }	
+    }
 }
 
 /// Handler for MetaAction messages.
@@ -379,16 +411,15 @@ impl Handler<MetaActionMessage> for GameHub {
     type Result = ();
 
     fn handle(&mut self, msg: MetaActionMessage, _: &mut Context<Self>) {
-	let MetaActionMessage { id, meta_action } = msg;
-	println!("handling MetaActionMessage in the hub! {:?}", meta_action);	
+        let MetaActionMessage { id, meta_action } = msg;
+        println!("handling MetaActionMessage in the hub! {:?}", meta_action);
         if let Some(table_name) = self.players_to_table.get(&id) {
-	    // tell the table that a player is gone
-           if let Some(meta_actions) = self.tables_to_meta_actions.get_mut(table_name) {
-	       meta_actions.lock().unwrap().push_back(meta_action);
-           } else {
- 	       // this should not happen since the meta actions vec should be created at the same time as the game
-	   }
-	}
+            // tell the table that a player is gone
+            if let Some(meta_actions) = self.tables_to_meta_actions.get_mut(table_name) {
+                meta_actions.lock().unwrap().push_back(meta_action);
+            } else {
+                // this should not happen since the meta actions vec should be created at the same time as the game
+            }
+        }
     }
 }
-

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -247,7 +247,12 @@ impl Handler<Create> for GameHub {
             // the player is not in the main lobby,
             // so we must be waiting for the game to remove the player still
             println!("player config not in the main lobby, so they must already be at a game");
-            return Err(CreateGameError::AlreadyAtTable("todo".to_owned()));
+	    if let Some(table_name) = self.players_to_table.get(&id) {
+		return Err(CreateGameError::AlreadyAtTable(table_name.to_string()));
+	    } else {
+		println!("player not at lobby nor at a table");
+		return Err(CreateGameError::AlreadyAtTable("unknown".to_string()));		    
+	    }
         }
         let player_config = player_config_option.unwrap();
 
@@ -339,7 +344,6 @@ impl Handler<Create> for GameHub {
                 small_blind,
                 big_blind,
                 buy_in,
-                is_private, // TODO does the game even need this field
                 password,
             );
 

--- a/src/logic/card.rs
+++ b/src/logic/card.rs
@@ -27,21 +27,21 @@ pub enum Rank {
 
 impl fmt::Display for Rank {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-	let string = match self {
-	    Rank::Two => "2",
-	    Rank::Three => "3",
-	    Rank::Four => "4",
-	    Rank::Five => "5",
-	    Rank::Six => "6",
-	    Rank::Seven => "7",
-	    Rank::Eight => "8",
-	    Rank::Nine => "9",
-	    Rank::Ten => "T",
-	    Rank::Jack => "J",
-	    Rank::Queen => "Q",
-	    Rank::King => "K",
-	    Rank::Ace => "A",
-	};
+        let string = match self {
+            Rank::Two => "2",
+            Rank::Three => "3",
+            Rank::Four => "4",
+            Rank::Five => "5",
+            Rank::Six => "6",
+            Rank::Seven => "7",
+            Rank::Eight => "8",
+            Rank::Nine => "9",
+            Rank::Ten => "T",
+            Rank::Jack => "J",
+            Rank::Queen => "Q",
+            Rank::King => "K",
+            Rank::Ace => "A",
+        };
         write!(f, "{}", string)
     }
 }
@@ -56,12 +56,12 @@ pub enum Suit {
 
 impl fmt::Display for Suit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-	let string = match self {
-	    Suit::Club => "c",
-	    Suit::Diamond => "d",
-	    Suit::Heart => "h",
-	    Suit::Spade => "s",
-	};
+        let string = match self {
+            Suit::Club => "c",
+            Suit::Diamond => "d",
+            Suit::Heart => "h",
+            Suit::Spade => "s",
+        };
         write!(f, "{}", string)
     }
 }
@@ -153,19 +153,20 @@ impl PartialEq for HandResult {
 }
 impl ToString for HandResult {
     fn to_string(&self) -> String {
-	format!("{:?}: {}, {}",
-		self.hand_ranking,
-		self.constituent_cards
-		.iter()
-		.map(|x| x.to_string())
-		.collect::<Vec<String>>()
-		.join("-"),
-		self.kickers
-		.iter()
-		.map(|x| x.to_string())
-		.collect::<Vec<String>>()
-		.join("-")
-	)
+        format!(
+            "{:?}: {}, {}",
+            self.hand_ranking,
+            self.constituent_cards
+                .iter()
+                .map(|x| x.to_string())
+                .collect::<Vec<String>>()
+                .join("-"),
+            self.kickers
+                .iter()
+                .map(|x| x.to_string())
+                .collect::<Vec<String>>()
+                .join("-")
+        )
     }
 }
 
@@ -182,23 +183,23 @@ impl HandResult {
         let mut value = hand_ranking as u32;
         value <<= 20; // shift it into the most significant area we need
 
-	// add the values of the constituent cards and then kickers
-	// note that this is only a tie breaker when the handranking is the same for both hands
-	// e.g. a pair of Kings will lead to higher "extra" bit value than a two-pair of 5s and 6s,
-	// but the original significant bits will be higher for the two-pair
-	
-	// The constituent cards have more significant value than the kickers,
-	// e.g. a pair of Queens with a highest card of 6 in its kickers will get a higher score
-	// than a pair of 10s with a highest card of King in its kickers (because the King doesn't get added
-	// until we are dealing with the kicker bits, and the Queens get a higher score than the 10s)
+        // add the values of the constituent cards and then kickers
+        // note that this is only a tie breaker when the handranking is the same for both hands
+        // e.g. a pair of Kings will lead to higher "extra" bit value than a two-pair of 5s and 6s,
+        // but the original significant bits will be higher for the two-pair
+
+        // The constituent cards have more significant value than the kickers,
+        // e.g. a pair of Queens with a highest card of 6 in its kickers will get a higher score
+        // than a pair of 10s with a highest card of King in its kickers (because the King doesn't get added
+        // until we are dealing with the kicker bits, and the Queens get a higher score than the 10s)
         let mut shift_amount = 16;
         for card in constituent_cards.iter().rev() {
-	    // the highest cards are shifted all the way to the left
+            // the highest cards are shifted all the way to the left
             let mut extra = card.rank as u32;
             extra <<= shift_amount;
             value += extra;
             shift_amount -= 4;
-        }	
+        }
         for kicker in kickers.iter().rev() {
             let mut extra = kicker.rank as u32;
             extra <<= shift_amount;
@@ -221,7 +222,7 @@ impl HandResult {
         let mut is_flush = true;
         let first_suit = five_cards[0].suit;
         let mut is_straight = true;
-	let mut is_low_ace_straight = false;
+        let mut is_low_ace_straight = false;
         let first_rank = five_cards[0].rank as usize;
         for (i, card) in five_cards.iter().enumerate() {
             let count = rank_counts.entry(card.rank).or_insert(0);
@@ -229,10 +230,10 @@ impl HandResult {
             if card.suit != first_suit {
                 is_flush = false;
             }
-	    if i == 4 && card.rank == Rank::Ace && first_rank == 2 {
-		// completing the straight with an Ace on 2-->Ace
-		is_low_ace_straight = true;
-	    } else if card.rank as usize != first_rank + i {
+            if i == 4 && card.rank == Rank::Ace && first_rank == 2 {
+                // completing the straight with an Ace on 2-->Ace
+                is_low_ace_straight = true;
+            } else if card.rank as usize != first_rank + i {
                 is_straight = false;
             }
         }
@@ -317,20 +318,20 @@ impl HandResult {
         }
         constituent_cards.sort();
 
-	if hand_ranking == HandRanking::FullHouse {
-	    // for a full house we actually want to make sure the sort has the 3 of a kind
-	    // sorted "higher" than the pair (since that is what matters more when determining
-	    // hand value)
-	    if constituent_cards[0].rank == constituent_cards[2].rank {
-		constituent_cards.reverse();
-	    }
-	} else if is_low_ace_straight {
-	    // we want the constituent cards to be sorted with the Ace being "low",
-	    // so we need to move it to the beginning
-	    let ace = constituent_cards.pop().unwrap();
-	    constituent_cards.insert(0, ace);
-	}
-	
+        if hand_ranking == HandRanking::FullHouse {
+            // for a full house we actually want to make sure the sort has the 3 of a kind
+            // sorted "higher" than the pair (since that is what matters more when determining
+            // hand value)
+            if constituent_cards[0].rank == constituent_cards[2].rank {
+                constituent_cards.reverse();
+            }
+        } else if is_low_ace_straight {
+            // we want the constituent cards to be sorted with the Ace being "low",
+            // so we need to move it to the beginning
+            let ace = constituent_cards.pop().unwrap();
+            constituent_cards.insert(0, ace);
+        }
+
         kickers.sort();
         let value = HandResult::score_hand(hand_ranking, &constituent_cards, &kickers);
         Self {
@@ -341,7 +342,6 @@ impl HandResult {
         }
     }
 }
-
 
 /// trait to define behaviour that you would expect out of a deck of cards
 /// in unit tests, we may want to provide a rigged deck, wherease in a normal game
@@ -393,7 +393,6 @@ impl Deck for StandardDeck {
     }
 }
 
-
 #[derive(Debug)]
 pub struct RiggedDeck {
     cards: Vec<Card>,
@@ -409,7 +408,7 @@ impl RiggedDeck {
     /// push a card into the deck.
     /// we can set the order exactly how we want
     pub fn push(&mut self, card: Card) {
-	self.cards.push(card);
+        self.cards.push(card);
     }
 }
 
@@ -432,275 +431,583 @@ impl Deck for RiggedDeck {
 
 #[cfg(test)]
 mod tests {
-     use super::*;
+    use super::*;
 
     #[test]
     fn ace_high_low() {
         let hand1 = vec![
-	    Card{rank: Rank::Ace, suit: Suit::Spade},
-	    Card{rank: Rank::Two, suit: Suit::Spade},
-	    Card{rank: Rank::Three, suit: Suit::Heart},
-	    Card{rank: Rank::Four, suit: Suit::Heart},
-	    Card{rank: Rank::Five, suit: Suit::Spade},	    
-	];
-	let result1 = HandResult::analyze_hand(hand1);
+            Card {
+                rank: Rank::Ace,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Two,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Three,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::Four,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::Five,
+                suit: Suit::Spade,
+            },
+        ];
+        let result1 = HandResult::analyze_hand(hand1);
         assert_eq!(result1.hand_ranking, HandRanking::Straight);
 
         let hand2 = vec![
-	    Card{rank: Rank::Three, suit: Suit::Spade},
-	    Card{rank: Rank::Four, suit: Suit::Club},
-	    Card{rank: Rank::Five, suit: Suit::Spade},
-	    Card{rank: Rank::Six, suit: Suit::Heart},
-	    Card{rank: Rank::Seven, suit: Suit::Spade},	    
-	];
-	
-	let result2 = HandResult::analyze_hand(hand2);
+            Card {
+                rank: Rank::Three,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Four,
+                suit: Suit::Club,
+            },
+            Card {
+                rank: Rank::Five,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Six,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::Seven,
+                suit: Suit::Spade,
+            },
+        ];
+
+        let result2 = HandResult::analyze_hand(hand2);
         assert_eq!(result2.hand_ranking, HandRanking::Straight);
-	assert!(result1 < result2);
+        assert!(result1 < result2);
 
         let hand3 = vec![
-	    Card{rank: Rank::Ten, suit: Suit::Spade},
-	    Card{rank: Rank::Jack, suit: Suit::Club},
-	    Card{rank: Rank::Queen, suit: Suit::Spade},
-	    Card{rank: Rank::King, suit: Suit::Heart},
-	    Card{rank: Rank::Ace, suit: Suit::Spade},	    
-	];
-	
-	let result3 = HandResult::analyze_hand(hand3);
-        assert_eq!(result3.hand_ranking, HandRanking::Straight);
-	assert!(result1 < result3);
-	assert!(result2 < result3);		
+            Card {
+                rank: Rank::Ten,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Jack,
+                suit: Suit::Club,
+            },
+            Card {
+                rank: Rank::Queen,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::King,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::Ace,
+                suit: Suit::Spade,
+            },
+        ];
 
+        let result3 = HandResult::analyze_hand(hand3);
+        assert_eq!(result3.hand_ranking, HandRanking::Straight);
+        assert!(result1 < result3);
+        assert!(result2 < result3);
     }
-    
+
     #[test]
     fn compare_high_card_and_pair() {
         let hand1 = vec![
-	    Card{rank: Rank::Two, suit: Suit::Spade},
-	    Card{rank: Rank::Four, suit: Suit::Spade},
-	    Card{rank: Rank::Five, suit: Suit::Heart},
-	    Card{rank: Rank::Nine, suit: Suit::Heart},
-	    Card{rank: Rank::Jack, suit: Suit::Spade},	    
-	];
-	let result1 = HandResult::analyze_hand(hand1);
+            Card {
+                rank: Rank::Two,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Four,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Five,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::Nine,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::Jack,
+                suit: Suit::Spade,
+            },
+        ];
+        let result1 = HandResult::analyze_hand(hand1);
         assert_eq!(result1.hand_ranking, HandRanking::HighCard);
 
         let hand2 = vec![
-	    Card{rank: Rank::Two, suit: Suit::Spade},
-	    Card{rank: Rank::Two, suit: Suit::Club},
-	    Card{rank: Rank::Three, suit: Suit::Spade},
-	    Card{rank: Rank::Seven, suit: Suit::Heart},
-	    Card{rank: Rank::Nine, suit: Suit::Spade},	    
-	];
-	
-	let result2 = HandResult::analyze_hand(hand2);
+            Card {
+                rank: Rank::Two,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Two,
+                suit: Suit::Club,
+            },
+            Card {
+                rank: Rank::Three,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Seven,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::Nine,
+                suit: Suit::Spade,
+            },
+        ];
+
+        let result2 = HandResult::analyze_hand(hand2);
         assert_eq!(result2.hand_ranking, HandRanking::Pair);
         assert_eq!(
-	    result2.constituent_cards,
-	    vec![
-	    	Card{rank: Rank::Two, suit: Suit::Spade},
-		Card{rank: Rank::Two, suit: Suit::Club},
-	    ]
-	);
+            result2.constituent_cards,
+            vec![
+                Card {
+                    rank: Rank::Two,
+                    suit: Suit::Spade
+                },
+                Card {
+                    rank: Rank::Two,
+                    suit: Suit::Club
+                },
+            ]
+        );
 
-	assert!(result1 < result2);
+        assert!(result1 < result2);
     }
-    
+
     #[test]
     fn compare_two_pair_and_three() {
         let hand1 = vec![
-	    Card{rank: Rank::Two, suit: Suit::Spade},
-	    Card{rank: Rank::Two, suit: Suit::Heart},
-	    Card{rank: Rank::Five, suit: Suit::Heart},
-	    Card{rank: Rank::Five, suit: Suit::Diamond},
-	    Card{rank: Rank::Jack, suit: Suit::Spade},	    
-	];
-	let result1 = HandResult::analyze_hand(hand1);
+            Card {
+                rank: Rank::Two,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Two,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::Five,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::Five,
+                suit: Suit::Diamond,
+            },
+            Card {
+                rank: Rank::Jack,
+                suit: Suit::Spade,
+            },
+        ];
+        let result1 = HandResult::analyze_hand(hand1);
         assert_eq!(result1.hand_ranking, HandRanking::TwoPair);
         assert_eq!(
-	    result1.constituent_cards,
-	    vec![
-	    Card{rank: Rank::Two, suit: Suit::Spade},
-	    Card{rank: Rank::Two, suit: Suit::Heart},
-	    Card{rank: Rank::Five, suit: Suit::Heart},
-	    Card{rank: Rank::Five, suit: Suit::Diamond},		
-	    ]
-	);
+            result1.constituent_cards,
+            vec![
+                Card {
+                    rank: Rank::Two,
+                    suit: Suit::Spade
+                },
+                Card {
+                    rank: Rank::Two,
+                    suit: Suit::Heart
+                },
+                Card {
+                    rank: Rank::Five,
+                    suit: Suit::Heart
+                },
+                Card {
+                    rank: Rank::Five,
+                    suit: Suit::Diamond
+                },
+            ]
+        );
 
         let hand2 = vec![
-	    Card{rank: Rank::King, suit: Suit::Spade},
-	    Card{rank: Rank::King, suit: Suit::Heart},
-	    Card{rank: Rank::King, suit: Suit::Diamond},
-	    Card{rank: Rank::Five, suit: Suit::Diamond},
-	    Card{rank: Rank::Jack, suit: Suit::Spade},	    
-	    
-	];
-	
-	let result2 = HandResult::analyze_hand(hand2);
+            Card {
+                rank: Rank::King,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::King,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::King,
+                suit: Suit::Diamond,
+            },
+            Card {
+                rank: Rank::Five,
+                suit: Suit::Diamond,
+            },
+            Card {
+                rank: Rank::Jack,
+                suit: Suit::Spade,
+            },
+        ];
+
+        let result2 = HandResult::analyze_hand(hand2);
         assert_eq!(result2.hand_ranking, HandRanking::ThreeOfAKind);
         assert_eq!(
-	    result2.constituent_cards,
-	    vec![
-	    Card{rank: Rank::King, suit: Suit::Spade},
-	    Card{rank: Rank::King, suit: Suit::Heart},
-	    Card{rank: Rank::King, suit: Suit::Diamond},		
-	    ]
-	);
+            result2.constituent_cards,
+            vec![
+                Card {
+                    rank: Rank::King,
+                    suit: Suit::Spade
+                },
+                Card {
+                    rank: Rank::King,
+                    suit: Suit::Heart
+                },
+                Card {
+                    rank: Rank::King,
+                    suit: Suit::Diamond
+                },
+            ]
+        );
 
-	assert!(result1 < result2);
+        assert!(result1 < result2);
     }
 
     #[test]
     fn compare_high_cards() {
         let hand1 = vec![
-	    Card{rank: Rank::Two, suit: Suit::Spade},
-	    Card{rank: Rank::Seven, suit: Suit::Spade},
-	    Card{rank: Rank::Eight, suit: Suit::Diamond},
-	    Card{rank: Rank::Jack, suit: Suit::Spade},
-	    Card{rank: Rank::King, suit: Suit::Spade},	    
-	];
-	let result1 = HandResult::analyze_hand(hand1);
+            Card {
+                rank: Rank::Two,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Seven,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Eight,
+                suit: Suit::Diamond,
+            },
+            Card {
+                rank: Rank::Jack,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::King,
+                suit: Suit::Spade,
+            },
+        ];
+        let result1 = HandResult::analyze_hand(hand1);
         assert_eq!(result1.hand_ranking, HandRanking::HighCard);
 
         let hand2 = vec![
-	    Card{rank: Rank::Two, suit: Suit::Spade},
-	    Card{rank: Rank::Five, suit: Suit::Spade}, // the 5 is less than the 7
-	    Card{rank: Rank::Eight, suit: Suit::Diamond},
-	    Card{rank: Rank::Jack, suit: Suit::Spade},
-	    Card{rank: Rank::King, suit: Suit::Spade},	    	    
-	];
-	
-	let result2 = HandResult::analyze_hand(hand2);
+            Card {
+                rank: Rank::Two,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Five,
+                suit: Suit::Spade,
+            }, // the 5 is less than the 7
+            Card {
+                rank: Rank::Eight,
+                suit: Suit::Diamond,
+            },
+            Card {
+                rank: Rank::Jack,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::King,
+                suit: Suit::Spade,
+            },
+        ];
+
+        let result2 = HandResult::analyze_hand(hand2);
         assert_eq!(result2.hand_ranking, HandRanking::HighCard);
-	assert!(result1 > result2);
+        assert!(result1 > result2);
     }
-    
+
     #[test]
     fn compare_straights() {
         let hand1 = vec![
-	    Card{rank: Rank::Two, suit: Suit::Spade},
-	    Card{rank: Rank::Three, suit: Suit::Heart},
-	    Card{rank: Rank::Four, suit: Suit::Heart},
-	    Card{rank: Rank::Five, suit: Suit::Diamond},
-	    Card{rank: Rank::Six, suit: Suit::Spade},	    
-	];
-	let result1 = HandResult::analyze_hand(hand1);
+            Card {
+                rank: Rank::Two,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Three,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::Four,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::Five,
+                suit: Suit::Diamond,
+            },
+            Card {
+                rank: Rank::Six,
+                suit: Suit::Spade,
+            },
+        ];
+        let result1 = HandResult::analyze_hand(hand1);
         assert_eq!(result1.hand_ranking, HandRanking::Straight);
 
         let hand2 = vec![
-	    Card{rank: Rank::Nine, suit: Suit::Spade},
-	    Card{rank: Rank::Ten, suit: Suit::Heart},
-	    Card{rank: Rank::Jack, suit: Suit::Diamond},
-	    Card{rank: Rank::Queen, suit: Suit::Diamond},
-	    Card{rank: Rank::King, suit: Suit::Spade},	    
-	    
-	];
-	
-	let result2 = HandResult::analyze_hand(hand2);
+            Card {
+                rank: Rank::Nine,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Ten,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::Jack,
+                suit: Suit::Diamond,
+            },
+            Card {
+                rank: Rank::Queen,
+                suit: Suit::Diamond,
+            },
+            Card {
+                rank: Rank::King,
+                suit: Suit::Spade,
+            },
+        ];
+
+        let result2 = HandResult::analyze_hand(hand2);
         assert_eq!(result2.hand_ranking, HandRanking::Straight);
-	assert!(result1 < result2);
+        assert!(result1 < result2);
     }
 
     /// these flushes have some cards in common (as will happen in a real game)
     #[test]
     fn compare_flushes() {
         let hand1 = vec![
-	    Card{rank: Rank::Two, suit: Suit::Spade},
-	    Card{rank: Rank::Seven, suit: Suit::Spade},
-	    Card{rank: Rank::Eight, suit: Suit::Spade},
-	    Card{rank: Rank::Jack, suit: Suit::Spade},
-	    Card{rank: Rank::King, suit: Suit::Spade},	    
-	];
-	let result1 = HandResult::analyze_hand(hand1);
+            Card {
+                rank: Rank::Two,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Seven,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Eight,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Jack,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::King,
+                suit: Suit::Spade,
+            },
+        ];
+        let result1 = HandResult::analyze_hand(hand1);
         assert_eq!(result1.hand_ranking, HandRanking::Flush);
 
         let hand2 = vec![
-	    Card{rank: Rank::Two, suit: Suit::Spade},
-	    Card{rank: Rank::Five, suit: Suit::Spade}, // the 5 is less than the 7
-	    Card{rank: Rank::Eight, suit: Suit::Spade},
-	    Card{rank: Rank::Jack, suit: Suit::Spade},
-	    Card{rank: Rank::King, suit: Suit::Spade},	    	    
-	];
-	
-	let result2 = HandResult::analyze_hand(hand2);
+            Card {
+                rank: Rank::Two,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Five,
+                suit: Suit::Spade,
+            }, // the 5 is less than the 7
+            Card {
+                rank: Rank::Eight,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Jack,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::King,
+                suit: Suit::Spade,
+            },
+        ];
+
+        let result2 = HandResult::analyze_hand(hand2);
         assert_eq!(result2.hand_ranking, HandRanking::Flush);
-	assert!(result1 > result2);
-    }    
+        assert!(result1 > result2);
+    }
 
     #[test]
     fn compare_full_houses() {
         let hand1 = vec![
-	    Card{rank: Rank::Two, suit: Suit::Spade},
-	    Card{rank: Rank::Two, suit: Suit::Heart},
-	    Card{rank: Rank::Queen, suit: Suit::Spade},
-	    Card{rank: Rank::Queen, suit: Suit::Heart},
-	    Card{rank: Rank::Queen, suit: Suit::Club},	    
-	];
-	let result1 = HandResult::analyze_hand(hand1);
+            Card {
+                rank: Rank::Two,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Two,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::Queen,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Queen,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::Queen,
+                suit: Suit::Club,
+            },
+        ];
+        let result1 = HandResult::analyze_hand(hand1);
         assert_eq!(result1.hand_ranking, HandRanking::FullHouse);
 
         let hand2 = vec![
-	    Card{rank: Rank::Two, suit: Suit::Spade},
-	    Card{rank: Rank::Two, suit: Suit::Heart},
-	    Card{rank: Rank::Two, suit: Suit::Diamond},
-	    Card{rank: Rank::Queen, suit: Suit::Heart},
-	    Card{rank: Rank::Queen, suit: Suit::Club},	    
-	];
-	
-	let result2 = HandResult::analyze_hand(hand2);
+            Card {
+                rank: Rank::Two,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Two,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::Two,
+                suit: Suit::Diamond,
+            },
+            Card {
+                rank: Rank::Queen,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::Queen,
+                suit: Suit::Club,
+            },
+        ];
+
+        let result2 = HandResult::analyze_hand(hand2);
         assert_eq!(result2.hand_ranking, HandRanking::FullHouse);
-	assert!(result1 > result2);
-    }    
+        assert!(result1 > result2);
+    }
 
     #[test]
     fn compare_full_houses_2() {
-	// the fives should beat the twos
+        // the fives should beat the twos
         let hand1 = vec![
-	    Card{rank: Rank::Five, suit: Suit::Spade},
-	    Card{rank: Rank::Five, suit: Suit::Heart},
-	    Card{rank: Rank::Five, suit: Suit::Diamond},
-	    Card{rank: Rank::Jack, suit: Suit::Heart},
-	    Card{rank: Rank::Jack, suit: Suit::Club},	    
-	];
-	let result1 = HandResult::analyze_hand(hand1);
+            Card {
+                rank: Rank::Five,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Five,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::Five,
+                suit: Suit::Diamond,
+            },
+            Card {
+                rank: Rank::Jack,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::Jack,
+                suit: Suit::Club,
+            },
+        ];
+        let result1 = HandResult::analyze_hand(hand1);
         assert_eq!(result1.hand_ranking, HandRanking::FullHouse);
 
         let hand2 = vec![
-	    Card{rank: Rank::Two, suit: Suit::Spade},
-	    Card{rank: Rank::Two, suit: Suit::Heart},
-	    Card{rank: Rank::Two, suit: Suit::Diamond},
-	    Card{rank: Rank::Queen, suit: Suit::Heart},
-	    Card{rank: Rank::Queen, suit: Suit::Club},	    
-	];
-	
-	let result2 = HandResult::analyze_hand(hand2);
+            Card {
+                rank: Rank::Two,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Two,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::Two,
+                suit: Suit::Diamond,
+            },
+            Card {
+                rank: Rank::Queen,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::Queen,
+                suit: Suit::Club,
+            },
+        ];
+
+        let result2 = HandResult::analyze_hand(hand2);
         assert_eq!(result2.hand_ranking, HandRanking::FullHouse);
-	assert!(result1 > result2);
-    }    
-    
+        assert!(result1 > result2);
+    }
+
     #[test]
     fn compare_pairs() {
         let hand1 = vec![
-	    Card{rank: Rank::Two, suit: Suit::Spade},
-	    Card{rank: Rank::Three, suit: Suit::Heart},
-	    Card{rank: Rank::Six, suit: Suit::Club},	    	    
-	    Card{rank: Rank::Queen, suit: Suit::Spade},
-	    Card{rank: Rank::Queen, suit: Suit::Heart},
-	];
-	let result1 = HandResult::analyze_hand(hand1);
+            Card {
+                rank: Rank::Two,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Three,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::Six,
+                suit: Suit::Club,
+            },
+            Card {
+                rank: Rank::Queen,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Queen,
+                suit: Suit::Heart,
+            },
+        ];
+        let result1 = HandResult::analyze_hand(hand1);
         assert_eq!(result1.hand_ranking, HandRanking::Pair);
 
         let hand2 = vec![
-	    Card{rank: Rank::Two, suit: Suit::Spade},
-	    Card{rank: Rank::Three, suit: Suit::Heart},
-	    Card{rank: Rank::Ten, suit: Suit::Heart},
-	    Card{rank: Rank::Ten, suit: Suit::Club},
-	    Card{rank: Rank::King, suit: Suit::Diamond},	    
-	];
-	
-	let result2 = HandResult::analyze_hand(hand2);
+            Card {
+                rank: Rank::Two,
+                suit: Suit::Spade,
+            },
+            Card {
+                rank: Rank::Three,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::Ten,
+                suit: Suit::Heart,
+            },
+            Card {
+                rank: Rank::Ten,
+                suit: Suit::Club,
+            },
+            Card {
+                rank: Rank::King,
+                suit: Suit::Diamond,
+            },
+        ];
+
+        let result2 = HandResult::analyze_hand(hand2);
         assert_eq!(result2.hand_ranking, HandRanking::Pair);
-	assert!(result1 > result2);
-    }    
-    
+        assert!(result1 > result2);
+    }
 }

--- a/src/logic/game.rs
+++ b/src/logic/game.rs
@@ -1380,7 +1380,35 @@ mod tests {
         assert_eq!(some_players, 1);
         assert!(game.players[0].as_ref().unwrap().human_controlled);
     }
-    
+
+    /// if we set max_players, then trying to add anyone past that point will
+    /// not work
+    #[test]
+    fn max_players_in_game_() {
+        let mut game = Game::default();
+       let max_players = 3;
+       game.max_players = max_players;
+
+       // we TRY to add 5 bots
+       for i in 0..5 {
+            let name = format!("Bot {}", i);
+            let index = game.add_bot(name);
+           if i < max_players {
+               assert_eq!(index.unwrap() as u8, i);
+           } else {
+               // above max_players, the returned index should be None
+               // i.e. the player was not added to the game
+               assert_eq!(index, None);
+           }
+       }
+        assert_eq!(game.players.len(), 9); // len of players always simply 9
+       
+       // flatten to get all the Some() players
+       let some_players = game.players.iter().flatten().count();
+       // but only max_players players are in the game at the end      
+        assert_eq!(some_players as u8, max_players);
+       
+    }
     
     /// the small blind folds, so the big blind should win and get paid
     #[test]

--- a/src/logic/game.rs
+++ b/src/logic/game.rs
@@ -184,7 +184,7 @@ impl GameHand {
 
 }
 
-impl Game {
+impl <'a> Game {
     
     fn transition(&mut self, mut gamehand: GameHand) {
         let pause_duration = time::Duration::from_secs(2); 	
@@ -984,10 +984,10 @@ impl Game {
 }
 
 #[derive(Debug)]
-pub struct Game {
+pub struct Game<'a> {
     hub_addr: Option<Addr<GameHub>>, // needs to be able to communicate back to the hub sometimes
-    incoming_actions: Option<&Arc<Mutex<HashMap<Uuid, PlayerAction>>>>,
-    incoming_meta_actions: Option<&Arc<Mutex<VecDeque<MetaAction>>>>,	
+    incoming_actions: Option<&'a Arc<Mutex<HashMap<Uuid, PlayerAction>>>>,
+    incoming_meta_actions: Option<&'a Arc<Mutex<VecDeque<MetaAction>>>>,	
     pub name: String,
     deck: Box<dyn Deck>,
     players: [Option<Player>; 9], // 9 spots where players can sit
@@ -1002,7 +1002,7 @@ pub struct Game {
 }
 
 /// useful for unit tests, for example
-impl Default for Game {
+impl<'a> Default for Game<'a> {
     fn default() -> Self {
         Self {
 	    hub_addr: None,
@@ -1024,8 +1024,7 @@ impl Default for Game {
     }
 }
 
-impl Game {
-
+impl<'a> Game<'a> {
     /// the address of the GameHub is optional so that unit tests need not worry about it
     /// We can pass in a custom Deck object, but if not, we will just construct a StandardDeck
     pub fn new(

--- a/src/logic/game.rs
+++ b/src/logic/game.rs
@@ -1,15 +1,15 @@
+use actix::Addr;
+use json::object;
 use rand::Rng;
 use std::cmp;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::iter;
-use std::sync::{Arc, Mutex};
-use actix::Addr;
-use json::object;
+use std::sync::Mutex;
 
-use super::card::{Card, Deck, StandardDeck, HandResult};
+use super::card::{Card, Deck, HandResult, StandardDeck};
 use super::player::{Player, PlayerAction, PlayerConfig};
-use crate::messages::{MetaAction, Removed};
 use crate::hub::GameHub;
+use crate::messages::{MetaAction, Removed};
 
 use std::{thread, time};
 
@@ -28,20 +28,20 @@ enum Street {
 /// A game hand can have multiple pots, when players go all-in, and betting continues
 #[derive(Debug)]
 struct Pot {
-    money: u32, // total amount in this pot
+    money: u32,                        // total amount in this pot
     contributions: HashMap<Uuid, u32>, // which players have contributed to the pot, and how much
-    // the most that any one player can put in. If a player goes all-in into a pot, 
+    // the most that any one player can put in. If a player goes all-in into a pot,
     // then the cap is the amount that player has put in
-    cap: Option<u32>, 
+    cap: Option<u32>,
 }
 
 impl Pot {
     fn new() -> Self {
-	Self {
-	    money: 0,
-	    contributions: HashMap::new(),
-	    cap: None
-	}
+        Self {
+            money: 0,
+            contributions: HashMap::new(),
+            cap: None,
+        }
     }
 }
 
@@ -49,82 +49,95 @@ impl Pot {
 /// how contributed how much to each.
 #[derive(Debug)]
 struct PotManager {
-    pots: Vec<Pot>
+    pots: Vec<Pot>,
 }
 
 impl PotManager {
     fn new() -> Self {
-	// the pot manager starts with a single main pot
-	Self {
-	    pots: vec![Pot::new()],
-	}
+        // the pot manager starts with a single main pot
+        Self {
+            pots: vec![Pot::new()],
+        }
     }
 
     /// returns a vec of each pot.money for the all pots
     /// useful to pass to the front end
     fn simple_repr(&self) -> Vec<u32> {
-	self.pots.iter().map(|x| x.money).collect()
+        self.pots.iter().map(|x| x.money).collect()
     }
-    
+
     fn contribute(&mut self, player_id: Uuid, new: u32, all_in: bool) {
-	println!("inside contribute: {:?}, {:?}, all_in={:?}", player_id, new, all_in);
-	let mut to_contribute = new;
-	let mut push_pot = false;
-	let mut insert_pot: Option<(usize, u32)> = None; 
-	for (i, pot) in self.pots.iter_mut().enumerate() {
-	    let so_far = pot.contributions.entry(player_id).or_insert(0);
-	    if let Some(cap) = pot.cap {
-		println!("cap of {}", cap);		
-		if *so_far > cap {
-		    panic!("somehow player {} put in more than the cap for \
-				    the the pot at index {}", player_id, i);
-		} else if *so_far == cap {
-		    println!("we have already filled up this pot");
-		    continue
-		}
-		// else, we need to put more into the pot
-		let remaining = cap - *so_far; // amount left before the cap
-		if remaining >= to_contribute {
-		    println!("the new contribution fits since {} > {}", remaining, to_contribute);
-		    *so_far += to_contribute;
-		    pot.money += to_contribute;
-		    if all_in {
-			// our all-in is smaller than the previous all-in
-			println!("our all-in is smaller than the previous all-in");
-			//pot.cap = Some(pot.contributions[&player_id]);
-			insert_pot = Some((i, pot.contributions[&player_id]));
-		    }
-		    break;
-		} else {
-		    // we need to contribute to the cap, then put more in the next pot
-		    println!("we need to contribute to the cap, then put more in the next pot");
-		    *so_far += remaining;
-		    pot.money += remaining;
-		    assert!(*so_far == cap);
-		    to_contribute -= remaining;
-		    println!("still need to contribute {}", to_contribute)
-		}
-	    } else {
-		// there is not cap on this pot, so simply put the new money in for this player
-		println!("no cap");
-		*so_far += to_contribute;
-		pot.money += to_contribute;
-		if all_in {
-		    pot.cap = Some(pot.contributions[&player_id]);
-		    push_pot = true;
-		}
-		break;
-	    }
-	}
-	if push_pot {
-	    // need to add a new pot
-	    println!("adding a new pot!");
-	    self.pots.push(Pot::new());
-	} else if let Some((index, new_cap)) = insert_pot {
-	    println!("inserting a pot at index {} and a new cap {}", index+1, new_cap);
-	    self.pots.insert(index+1, Pot::new());
-	    self.transfer_excess(index, new_cap)
-	}
+        println!(
+            "inside contribute: {:?}, {:?}, all_in={:?}",
+            player_id, new, all_in
+        );
+        let mut to_contribute = new;
+        let mut push_pot = false;
+        let mut insert_pot: Option<(usize, u32)> = None;
+        for (i, pot) in self.pots.iter_mut().enumerate() {
+            let so_far = pot.contributions.entry(player_id).or_insert(0);
+            if let Some(cap) = pot.cap {
+                println!("cap of {}", cap);
+                if *so_far > cap {
+                    panic!(
+                        "somehow player {} put in more than the cap for \
+				    the the pot at index {}",
+                        player_id, i
+                    );
+                } else if *so_far == cap {
+                    println!("we have already filled up this pot");
+                    continue;
+                }
+                // else, we need to put more into the pot
+                let remaining = cap - *so_far; // amount left before the cap
+                if remaining >= to_contribute {
+                    println!(
+                        "the new contribution fits since {} > {}",
+                        remaining, to_contribute
+                    );
+                    *so_far += to_contribute;
+                    pot.money += to_contribute;
+                    if all_in {
+                        // our all-in is smaller than the previous all-in
+                        println!("our all-in is smaller than the previous all-in");
+                        //pot.cap = Some(pot.contributions[&player_id]);
+                        insert_pot = Some((i, pot.contributions[&player_id]));
+                    }
+                    break;
+                } else {
+                    // we need to contribute to the cap, then put more in the next pot
+                    println!("we need to contribute to the cap, then put more in the next pot");
+                    *so_far += remaining;
+                    pot.money += remaining;
+                    assert!(*so_far == cap);
+                    to_contribute -= remaining;
+                    println!("still need to contribute {}", to_contribute)
+                }
+            } else {
+                // there is not cap on this pot, so simply put the new money in for this player
+                println!("no cap");
+                *so_far += to_contribute;
+                pot.money += to_contribute;
+                if all_in {
+                    pot.cap = Some(pot.contributions[&player_id]);
+                    push_pot = true;
+                }
+                break;
+            }
+        }
+        if push_pot {
+            // need to add a new pot
+            println!("adding a new pot!");
+            self.pots.push(Pot::new());
+        } else if let Some((index, new_cap)) = insert_pot {
+            println!(
+                "inserting a pot at index {} and a new cap {}",
+                index + 1,
+                new_cap
+            );
+            self.pots.insert(index + 1, Pot::new());
+            self.transfer_excess(index, new_cap)
+        }
     }
 
     /// give the index of a newly created pot, we move any excess contributions from the pot
@@ -132,31 +145,31 @@ impl PotManager {
     /// se the new_cap
     /// this happens when a smaller all-in happens after a larger bet
     fn transfer_excess(&mut self, index: usize, new_cap: u32) {
-	let prev_pot = self.pots.get_mut(index).unwrap();
-	println!("prev_pot = {:?}", prev_pot);
-	let mut transfers = HashMap::<Uuid, u32>::new();
-	let prev_cap = prev_pot.cap.unwrap();
-	prev_pot.cap = Some(new_cap);
-	for (id, amount)  in prev_pot.contributions.iter_mut() {
-	    //let b: bool = id;
-	    if *amount > new_cap {
-		// we need to move the excess above the cap of the pot to the new pot
-		let excess = *amount - new_cap;
-		transfers.insert(*id, excess);
-		*amount = new_cap;
-		prev_pot.money -= excess;
-	    }
-	}
-	println!("after taking = {:?}", prev_pot);
-	println!("transfers = {:?}", transfers);	
-	let mut new_pot = self.pots.get_mut(index+1).unwrap();
-	new_pot.money = transfers.values().sum();	
-	new_pot.contributions = transfers;
+        let prev_pot = self.pots.get_mut(index).unwrap();
+        println!("prev_pot = {:?}", prev_pot);
+        let mut transfers = HashMap::<Uuid, u32>::new();
+        let prev_cap = prev_pot.cap.unwrap();
+        prev_pot.cap = Some(new_cap);
+        for (id, amount) in prev_pot.contributions.iter_mut() {
+            //let b: bool = id;
+            if *amount > new_cap {
+                // we need to move the excess above the cap of the pot to the new pot
+                let excess = *amount - new_cap;
+                transfers.insert(*id, excess);
+                *amount = new_cap;
+                prev_pot.money -= excess;
+            }
+        }
+        println!("after taking = {:?}", prev_pot);
+        println!("transfers = {:?}", transfers);
+        let mut new_pot = self.pots.get_mut(index + 1).unwrap();
+        new_pot.money = transfers.values().sum();
+        new_pot.contributions = transfers;
 
-	// the new pot is capped at the difference
-	// e.g. if someone was all-in with 750, then someone calls to go all-in with 500,
-	// the the pre_pot is NOW capped at 500, and the next pot is capped at 250
-	new_pot.cap = Some(prev_cap - new_cap); 
+        // the new pot is capped at the difference
+        // e.g. if someone was all-in with 750, then someone calls to go all-in with 500,
+        // the the pre_pot is NOW capped at 500, and the next pot is capped at 250
+        new_pot.cap = Some(prev_cap - new_cap);
     }
 }
 
@@ -175,20 +188,18 @@ impl GameHand {
         GameHand {
             street: Street::Preflop,
             pot_manager: PotManager::new(),
-	    total_contributions: [0; 9],
+            total_contributions: [0; 9],
             flop: None,
             turn: None,
             river: None,
         }
     }
-
 }
 
-impl <'a> Game {
-    
-    fn transition(&mut self, mut gamehand: GameHand) {
-        let pause_duration = time::Duration::from_secs(2); 	
-        thread::sleep(pause_duration);	
+impl<'a> Game<'a> {
+    fn transition(&mut self, gamehand: &mut GameHand) {
+        let pause_duration = time::Duration::from_secs(2);
+        thread::sleep(pause_duration);
         match gamehand.street {
             Street::Preflop => {
                 gamehand.street = Street::Flop;
@@ -197,16 +208,14 @@ impl <'a> Game {
                     "\n===========================\nFlop = {:?}\n===========================",
                     gamehand.flop
                 );
-		let message = object!{
-		    msg_type: "flop".to_owned(),
-                    flop: format!("{}{}{}",
-				  gamehand.flop.as_ref().unwrap()[0],
-				  gamehand.flop.as_ref().unwrap()[1],
-				  gamehand.flop.as_ref().unwrap()[2]),
-		};
-                PlayerConfig::send_group_message(
-		    &message.dump(),
-		    &self.player_ids_to_configs);		
+                let message = object! {
+                    msg_type: "flop".to_owned(),
+                            flop: format!("{}{}{}",
+                          gamehand.flop.as_ref().unwrap()[0],
+                          gamehand.flop.as_ref().unwrap()[1],
+                          gamehand.flop.as_ref().unwrap()[2]),
+                };
+                PlayerConfig::send_group_message(&message.dump(), &self.player_ids_to_configs);
             }
             Street::Flop => {
                 gamehand.street = Street::Turn;
@@ -215,13 +224,11 @@ impl <'a> Game {
                     "\n==========================\nTurn = {:?}\n==========================",
                     gamehand.turn
                 );
-		let message = object!{
-		    msg_type: "turn".to_owned(),
-                    turn: format!("{}", gamehand.turn.unwrap())
-		};
-                PlayerConfig::send_group_message(
-		    &message.dump(),
-		    &self.player_ids_to_configs);				
+                let message = object! {
+                    msg_type: "turn".to_owned(),
+                            turn: format!("{}", gamehand.turn.unwrap())
+                };
+                PlayerConfig::send_group_message(&message.dump(), &self.player_ids_to_configs);
             }
             Street::Turn => {
                 gamehand.street = Street::River;
@@ -230,14 +237,12 @@ impl <'a> Game {
                     "\n==========================\nRiver = {:?}\n==========================",
                     gamehand.river
                 );
-		let message = object!{
-		    msg_type: "river".to_owned(),
-                    river: format!("{}", gamehand.river.unwrap())
-		};
-                PlayerConfig::send_group_message(
-		    &message.dump(),
-		    &self.player_ids_to_configs);				
-	    }
+                let message = object! {
+                    msg_type: "river".to_owned(),
+                            river: format!("{}", gamehand.river.unwrap())
+                };
+                PlayerConfig::send_group_message(&message.dump(), &self.player_ids_to_configs);
+            }
             Street::River => {
                 gamehand.street = Street::ShowDown;
                 println!(
@@ -256,22 +261,22 @@ impl <'a> Game {
                         player.hole_cards.push(card)
                     } else {
                         panic!("The deck is out of cards somehow?");
-                    }		    
+                    }
                 }
-		let message = object!{
-		    msg_type: "hole_cards".to_owned(),
-		    hole_cards: format!("{}{}", player.hole_cards[0], player.hole_cards[1]),
-		};
-		PlayerConfig::send_specific_message(
-		    &message.dump(),
-		    player.id,
-		    &self.player_ids_to_configs
-		);
+                let message = object! {
+                    msg_type: "hole_cards".to_owned(),
+                    hole_cards: format!("{}{}", player.hole_cards[0], player.hole_cards[1]),
+                };
+                PlayerConfig::send_specific_message(
+                    &message.dump(),
+                    player.id,
+                    &self.player_ids_to_configs,
+                );
             }
         }
     }
 
-    fn deal_flop(&mut self, mut gamehand: GameHand) {
+    fn deal_flop(&mut self, gamehand: &mut GameHand) {
         let mut flop = Vec::<Card>::with_capacity(3);
         for _ in 0..3 {
             if let Some(card) = self.deck.draw_card() {
@@ -283,74 +288,78 @@ impl <'a> Game {
         gamehand.flop = Some(flop);
     }
 
-    fn deal_turn(&mut self, mut gamehand: GameHand) {
+    fn deal_turn(&mut self, gamehand: &mut GameHand) {
         gamehand.turn = self.deck.draw_card();
     }
 
-    fn deal_river(&mut self, mut gamehand: GameHand) {
+    fn deal_river(&mut self, gamehand: &mut GameHand) {
         gamehand.river = self.deck.draw_card();
     }
 
-    fn finish(&mut self, mut gamehand: GameHand) {
-	// pause for a second for dramatic effect heh
-        let pause_duration = time::Duration::from_secs(2); 	
+    fn finish(&mut self, gamehand: &mut GameHand) {
+        // pause for a second for dramatic effect heh
+        let pause_duration = time::Duration::from_secs(2);
         thread::sleep(pause_duration);
-	
-        let hand_results: HashMap<Uuid, Option<HandResult>>  = self.players
+
+        let hand_results: HashMap<Uuid, Option<HandResult>> = self
+            .players
             .iter()
             .flatten()
-            .map(|player| {return (player.id, self.determine_best_hand(player, gamehand))})
+            .map(|player| return (player.id, self.determine_best_hand(player, gamehand)))
             .collect();
 
-	let is_showdown = gamehand.street == Street::ShowDown;
-	println!("hand results = {:?}", hand_results);
+        let is_showdown = gamehand.street == Street::ShowDown;
+        println!("hand results = {:?}", hand_results);
         if let Street::ShowDown = gamehand.street {
             // if we made it to show down, there are multiple players left, so we need to see who
             // has the best hand.
             println!("Multiple active players made it to showdown!");
-	    println!("{:?}", gamehand.pot_manager);
-	    for pot in gamehand.pot_manager.pots.iter() {
-		// for each pot, we determine who should get paid out
-		// a player can only get paid for a pot that they contributed to
-		// so each pot has its own best_hand calculation
-		println!("Looking at pot {:?}", pot);
-		let mut best_ids = HashSet::<Uuid>::new();		
-		let mut best_hand: Option<&HandResult> = None;		
-		for (id, current_opt) in hand_results.iter() {
-		    if pot.contributions.get(&id).is_none() {
-			println!("player id {} did not contribute to this pot!", id);
-			continue;
-		    }
+            println!("{:?}", gamehand.pot_manager);
+            for pot in gamehand.pot_manager.pots.iter() {
+                // for each pot, we determine who should get paid out
+                // a player can only get paid for a pot that they contributed to
+                // so each pot has its own best_hand calculation
+                println!("Looking at pot {:?}", pot);
+                let mut best_ids = HashSet::<Uuid>::new();
+                let mut best_hand: Option<&HandResult> = None;
+                for (id, current_opt) in hand_results.iter() {
+                    if pot.contributions.get(&id).is_none() {
+                        println!("player id {} did not contribute to this pot!", id);
+                        continue;
+                    }
                     if current_opt.is_none() {
-			continue;
+                        continue;
                     }
-		    if !self.player_ids_to_configs.contains_key(id) {
-			println!("player id {} no longer exists in the configs, they must have left!", id);
-			continue
-		    }
-		    let current_result = current_opt.as_ref().unwrap();
+                    if !self.player_ids_to_configs.contains_key(id) {
+                        println!(
+                            "player id {} no longer exists in the configs, they must have left!",
+                            id
+                        );
+                        continue;
+                    }
+                    let current_result = current_opt.as_ref().unwrap();
                     if best_hand.is_none() || current_result > best_hand.unwrap() {
-			println!("new best hand for id {:?}", id);
-			best_hand = Some(current_result);
-			best_ids.clear();
-			best_ids.insert(*id); // only one best hand now
+                        println!("new best hand for id {:?}", id);
+                        best_hand = Some(current_result);
+                        best_ids.clear();
+                        best_ids.insert(*id); // only one best hand now
                     } else if current_result == best_hand.unwrap() {
-			println!("equally good hand for id {:?}", id);
-			best_ids.insert(*id); // another index that also has the best hand
+                        println!("equally good hand for id {:?}", id);
+                        best_ids.insert(*id); // another index that also has the best hand
                     } else {
-			println!("hand worse for id {:?}", id);
-			continue;
+                        println!("hand worse for id {:?}", id);
+                        continue;
                     }
-		}
-		// divy the pot to all the winners
-		let num_winners = best_ids.len();
-		let payout = (pot.money as f64 / num_winners as f64) as u32;
-		//self.pot_manager.pots.first_mut().unwrap().money = 0;		
-		self.pay_players(best_ids, payout, &hand_results, is_showdown);
-	    }
+                }
+                // divy the pot to all the winners
+                let num_winners = best_ids.len();
+                let payout = (pot.money as f64 / num_winners as f64) as u32;
+                //self.pot_manager.pots.first_mut().unwrap().money = 0;
+                self.pay_players(best_ids, payout, &hand_results, is_showdown);
+            }
         } else {
             // the hand ended before Showdown, so we simple find the one active player remaining
-            let mut best_ids = HashSet::<Uuid>::new();	    
+            let mut best_ids = HashSet::<Uuid>::new();
             for player in self.players.iter().flatten() {
                 if player.is_active {
                     //println!("found an active player remaining");
@@ -359,11 +368,14 @@ impl <'a> Game {
                     println!("found an NON active player remaining");
                 }
             }
-	    // if we didn't make it to show down, there better be only one player left	    
+            // if we didn't make it to show down, there better be only one player left
             assert!(best_ids.len() == 1);
-	    self.pay_players(best_ids,
-			     gamehand.pot_manager.pots.first().unwrap().money,
-			     &hand_results, is_showdown);
+            self.pay_players(
+                best_ids,
+                gamehand.pot_manager.pots.first().unwrap().money,
+                &hand_results,
+                is_showdown,
+            );
         }
 
         // take the players' cards
@@ -373,59 +385,57 @@ impl <'a> Game {
         }
     }
 
-
     fn pay_players(
-	&mut self,
-	best_ids: HashSet::<Uuid>,
-	payout: u32,
+        &mut self,
+        best_ids: HashSet<Uuid>,
+        payout: u32,
         hand_results: &HashMap<Uuid, Option<HandResult>>,
-	is_showdown: bool
+        is_showdown: bool,
     ) {
-	println!("best_indices = {:?}", best_ids);
-	for player in self.players.iter_mut().flatten() {
-	    if best_ids.contains(&player.id) {
-		// get the name for messages		    
-		let name: String = if let Some(config) = &self.player_ids_to_configs.get(&player.id) {
-		    config.name.as_ref().unwrap().clone()
-		} else {
-		    // it is a bit weird if we made it all the way to the pay stage for a left player		    
-		    "Player who left".to_string()
-		};		
-		let ranking_string = if let Some(hand_result) = hand_results.get(&player.id).unwrap() {
-		    hand_result.to_string()
-		} else {
-		    "Unknown".to_string()
-		};
-		println!(
+        println!("best_indices = {:?}", best_ids);
+        for player in self.players.iter_mut().flatten() {
+            if best_ids.contains(&player.id) {
+                // get the name for messages
+                let name: String = if let Some(config) = &self.player_ids_to_configs.get(&player.id)
+                {
+                    config.name.as_ref().unwrap().clone()
+                } else {
+                    // it is a bit weird if we made it all the way to the pay stage for a left player
+                    "Player who left".to_string()
+                };
+                let ranking_string =
+                    if let Some(hand_result) = hand_results.get(&player.id).unwrap() {
+                        hand_result.to_string()
+                    } else {
+                        "Unknown".to_string()
+                    };
+                println!(
                     "paying out {:?} to {:?}, with hand result = {:?}",
                     payout, name, ranking_string
-		);
-		let hole_string = if is_showdown {
-		    format!("{}{}",player.hole_cards[0], player.hole_cards[1])
-		} else {
-		    "Unknown".to_string()
-		};
+                );
+                let hole_string = if is_showdown {
+                    format!("{}{}", player.hole_cards[0], player.hole_cards[1])
+                } else {
+                    "Unknown".to_string()
+                };
 
-		let message = object!{
-		    msg_type: "paying_out".to_owned(),
-		    payout: payout,
-		    player_name: name,
-		    hole_cards: hole_string,
-		    hand_result: ranking_string,
-		    is_showdown: is_showdown,
-		};
-		PlayerConfig::send_group_message(
-		    &message.dump(),
-		    &self.player_ids_to_configs
-		);			
-		player.pay(payout);
-		println!("after payment: {:?}", player);
-	    } 
+                let message = object! {
+                    msg_type: "paying_out".to_owned(),
+                    payout: payout,
+                    player_name: name,
+                    hole_cards: hole_string,
+                    hand_result: ranking_string,
+                    is_showdown: is_showdown,
+                };
+                PlayerConfig::send_group_message(&message.dump(), &self.player_ids_to_configs);
+                player.pay(payout);
+                println!("after payment: {:?}", player);
+            }
         }
     }
-    
+
     /// Given a player, we need to determine which 5 cards make the best hand for this player
-    fn determine_best_hand(&self, player: &Player, mut gamehand: GameHand) -> Option<HandResult> {	
+    fn determine_best_hand(&self, player: &Player, gamehand: &mut GameHand) -> Option<HandResult> {
         if !player.is_active {
             // if the player isn't active, then can't have a best hand
             return None;
@@ -473,59 +483,57 @@ impl <'a> Game {
             None
         }
     }
-    
+
     fn play_one_hand(&mut self) {
         println!("inside of play(). button_idx = {:?}", self.button_idx);
-	let mut gamehand = GameHand::default();
-	
-	for player in self.players.iter_mut().flatten() {
-	    if player.is_sitting_out || player.money == 0 {
-		player.is_active = false;		
-	    } else {
-		player.is_active = true;
-	    }
-	}
-	for (i, player_spot) in self.players.iter().enumerate() {
-	    // display the play positions for the front end to consume
-	    if let Some(player) = player_spot {
-		let mut message = object!{
-		    msg_type: "player_info".to_owned(),
-		    index: i
-		};
-		let config = self.player_ids_to_configs.get(&player.id).unwrap();
-		let name = config.name.as_ref().unwrap().clone();
-		message["player_name"] = name.into();
-		message["money"] = player.money.into();
-		message["is_active"] = player.is_active.into();		    
-		PlayerConfig::send_group_message(&message.dump(),
-						 &self.player_ids_to_configs);			
-	    } 
-	}	    	    
+        let mut gamehand = GameHand::default();
 
-	
+        for player in self.players.iter_mut().flatten() {
+            if player.is_sitting_out || player.money == 0 {
+                player.is_active = false;
+            } else {
+                player.is_active = true;
+            }
+        }
+        for (i, player_spot) in self.players.iter().enumerate() {
+            // display the play positions for the front end to consume
+            if let Some(player) = player_spot {
+                let mut message = object! {
+                    msg_type: "player_info".to_owned(),
+                    index: i
+                };
+                let config = self.player_ids_to_configs.get(&player.id).unwrap();
+                let name = config.name.as_ref().unwrap().clone();
+                message["player_name"] = name.into();
+                message["money"] = player.money.into();
+                message["is_active"] = player.is_active.into();
+                PlayerConfig::send_group_message(&message.dump(), &self.player_ids_to_configs);
+            }
+        }
+
         self.deck.shuffle();
         self.deal_hands();
 
         println!("players = {:?}", self.players);
 
         while gamehand.street != Street::ShowDown {
-	    // pause for a second for dramatic effect heh
-            let pause_duration = time::Duration::from_secs(2); 	
-            thread::sleep(pause_duration);	    
-            let finished = self.play_street(gamehand);
-	    if finished {
+            // pause for a second for dramatic effect heh
+            let pause_duration = time::Duration::from_secs(2);
+            thread::sleep(pause_duration);
+            let finished = self.play_street(&mut gamehand);
+            if finished {
                 // if the game is over from players folding
                 println!("\nGame is ending before showdown!");
-		// TODO is a msg here needed?
+                // TODO is a msg here needed?
                 //PlayerConfig::send_group_message("\nGame is ending before showdown!", player_ids_to_configs);
                 break;
             } else {
                 // otherwise we move to the next street
-                self.transition(gamehand)
-            }	    
+                self.transition(&mut gamehand)
+            }
         }
         // now we finish up and pay the pot to the winner
-        self.finish(gamehand);
+        self.finish(&mut gamehand);
     }
 
     fn get_starting_idx(&self) -> usize {
@@ -540,10 +548,7 @@ impl <'a> Game {
     }
 
     /// this method returns a bool indicating whether the hand is over or not
-    fn play_street(
-	&mut self,
-	mut gamehand: GameHand,
-    ) -> bool {
+    fn play_street(&mut self, gamehand: &mut GameHand) -> bool {
         let mut current_bet: u32 = 0;
         // each index keeps track of that players' contribution this street
         let mut cumulative_bets = vec![0; self.players.len()];
@@ -551,13 +556,15 @@ impl <'a> Game {
         let starting_idx = self.get_starting_idx(); // which player starts the betting
 
         // if a player is still active but has no remaining money (i.e. is all-in),
-        let mut num_all_in = self.players
+        let mut num_all_in = self
+            .players
             .iter()
             .flatten() // skip over None values
             .filter(|player| player.is_all_in())
             .count();
 
-        let mut num_active = self.players
+        let mut num_active = self
+            .players
             .iter()
             .flatten() // skip over None values
             .filter(|player| player.is_active)
@@ -570,217 +577,210 @@ impl <'a> Game {
             return true;
         }
 
-	if num_all_in + 1 == num_active {
-	    println!("only one person is not all in, so don't bother with the street!");
-            return false;		    
-	}
-	
-	// once every player is either all-in or settled, then we move to the next street	
+        if num_all_in + 1 == num_active {
+            println!("only one person is not all in, so don't bother with the street!");
+            return false;
+        }
+
+        // once every player is either all-in or settled, then we move to the next street
         let mut num_settled = 0; // keep track of how many players have put in enough chips to move on
-	
+
         println!("num active players = {}", num_active);
         //PlayerConfig::send_group_message(&format!("num active players = {}", num_active), player_ids_to_configs);
 
-	
         println!("player at index {} starts the betting", starting_idx);
         if num_settled > 0 {
             println!("num settled (i.e. all in players) = {}", num_settled);
-            PlayerConfig::send_group_message(&format!(
-                "num settled (i.e. all in players) = {}",
-                num_settled
-            ), &self.player_ids_to_configs);
+            PlayerConfig::send_group_message(
+                &format!("num settled (i.e. all in players) = {}", num_settled),
+                &self.player_ids_to_configs,
+            );
         }
         // iterate over the players from the starting index to the end of the vec,
         // and then from the beginning back to the starting index
         //let (left, right) = players.split_at_mut(starting_idx);
         //for (i, mut player) in right.iter_mut().chain(left.iter_mut()).flatten().enumerate() {
-	for i in (starting_idx..9).chain(0..starting_idx).cycle() {
-            println!("start loop index = {}: num_active = {}, num_settled = {}, num_all_in = {}",
-		     i, num_active, num_settled, num_all_in);		
-	    if num_active == 1 {
-		println!("Only one active player left so lets break the steet loop");
-		// end the street and indicate to the caller that the hand is finished
-		return true;
-	    }
-	    if num_settled + num_all_in == num_active {
-		println!(
-		    "everyone is ready to go to the next street! num_settled = {}",
-		    num_settled
-		);
-		// end the street and indicate to the caller that the hand is going to the next street
-		return false;
-	    }
+        for i in (starting_idx..9).chain(0..starting_idx).cycle() {
+            println!(
+                "start loop index = {}: num_active = {}, num_settled = {}, num_all_in = {}",
+                i, num_active, num_settled, num_all_in
+            );
+            if num_active == 1 {
+                println!("Only one active player left so lets break the steet loop");
+                // end the street and indicate to the caller that the hand is finished
+                return true;
+            }
+            if num_settled + num_all_in == num_active {
+                println!(
+                    "everyone is ready to go to the next street! num_settled = {}",
+                    num_settled
+                );
+                // end the street and indicate to the caller that the hand is going to the next street
+                return false;
+            }
 
-	    if self.players[i].is_none() {
-		// no one sitting in this spot
-		continue;
-	    }
+            if self.players[i].is_none() {
+                // no one sitting in this spot
+                continue;
+            }
 
-	    // we clone() the current player so that we can use its information
-	    // while also possibly updating players (if a player leaves or joins the game in handle_meta_actions)
-	    // if we handle_meta_actions BEFORE accessing the current player, then we will have to wait
-	    // a long time between user messages, which is a worse user experience
-	    // the Player struct is not super heavy to clone.
-	    let player = self.players[i].clone().unwrap();
-	    let player_cumulative = cumulative_bets[i];
-	    println!("Current pot = {:?}, Current size of the bet = {:?}, and this player has put in {:?} so far",
+            // we clone() the current player so that we can use its information
+            // while also possibly updating players (if a player leaves or joins the game in handle_meta_actions)
+            // if we handle_meta_actions BEFORE accessing the current player, then we will have to wait
+            // a long time between user messages, which is a worse user experience
+            // the Player struct is not super heavy to clone.
+            let player = self.players[i].clone().unwrap();
+            let player_cumulative = cumulative_bets[i];
+            println!("Current pot = {:?}, Current size of the bet = {:?}, and this player has put in {:?} so far",
 		     gamehand.pot_manager,
 		     current_bet,
 		     player_cumulative);
-	    println!("Player = {:?}, i = {}", player.id, i);
-	    if !(player.is_active && player.money > 0) {
-		continue;
-	    }
-	    // get the name for messages		    
-	    let name = if let Some(config) = &self.player_ids_to_configs.get(&player.id) {
-		config.name.as_ref().unwrap().clone()
-	    } else {
-		"Player who left".to_string()
-	    };
+            println!("Player = {:?}, i = {}", player.id, i);
+            if !(player.is_active && player.money > 0) {
+                continue;
+            }
+            // get the name for messages
+            let name = if let Some(config) = &self.player_ids_to_configs.get(&player.id) {
+                config.name.as_ref().unwrap().clone()
+            } else {
+                "Player who left".to_string()
+            };
 
-	    let message = object!{
-		msg_type: "player_to_act".to_owned(),				
-		index: i,
-		player_name: name.clone(),
-	    };
-	    
-	    PlayerConfig::send_group_message(
-		&message.dump(),
-		&self.player_ids_to_configs);
-	    
-	    let action = self.get_and_validate_action(
-		&player,
-		current_bet,
-		player_cumulative,
-		gamehand,
-	    );
+            let message = object! {
+            msg_type: "player_to_act".to_owned(),
+            index: i,
+            player_name: name.clone(),
+            };
 
-	    let mut message = object!{
-		msg_type: "player_action".to_owned(),				
-		index: i,
-		player_name: name
-	    };
+            PlayerConfig::send_group_message(&message.dump(), &self.player_ids_to_configs);
 
-	    // now that we have gotten the current player's action and handled
-	    // any meta actions, we are free to respond and mutate the player
-	    // so we re-borrow it as mutable
-	    let player = self.players[i].as_mut().unwrap();		
-	    match action {			
-		PlayerAction::PostSmallBlind(amount) => {
-		    message["action"] = "small blind".into();
-		    message["amount"] = amount.into();			    
-		    cumulative_bets[i] += amount;
-		    gamehand.total_contributions[i] += amount;
-		    player.money -= amount;
-		    // regardless if the player couldn't afford it, the new street bet is the big blind
-		    current_bet = self.small_blind;
-		    let all_in = if player.is_all_in() {
-			num_all_in += 1;
-			true
-		    } else {
-			false
-		    };
-		    gamehand.pot_manager.contribute(player.id, amount, all_in);
-		}
-		PlayerAction::PostBigBlind(amount) => {
-		    message["action"] = "big blind".into();
-		    message["amount"] = amount.into();			    			    
-		    cumulative_bets[i] += amount;
-		    gamehand.total_contributions[i] += amount;			    
-		    player.money -= amount;
-		    // regardless if the player couldn't afford it, the new street bet is the big blind
-		    current_bet = self.big_blind;
-		    let all_in = if player.is_all_in() {
-			num_all_in += 1;
-			true
-		    } else {
-			false
-		    };
-		    gamehand.pot_manager.contribute(player.id, amount, all_in);			    
-		    // note: we dont count the big blind as a "settled" player,
-		    // since they still get a chance to act after the small blind
-		}
-		PlayerAction::Fold => {
-		    message["action"] = "fold".into();			    
-		    player.deactivate();
-		    num_active -= 1;
-		}
-		PlayerAction::Check => {
-		    message["action"] = "check".into();			    
-		    num_settled += 1;
-		}
-		PlayerAction::Call => {
-		    message["action"] = "call".into();
-		    let difference = current_bet - player_cumulative;
-		    if difference >= player.money {
-			println!("you have to put in the rest of your chips");
-			gamehand.pot_manager.contribute(player.id, player.money, true);
-			cumulative_bets[i] += player.money;
-			gamehand.total_contributions[i] += player.money;
-			message["amount"] = player.money.into();		
-			player.money = 0;
-			num_all_in += 1;
-		    } else {
-			gamehand.pot_manager.contribute(player.id, difference, false);
-			cumulative_bets[i] += difference;
-			gamehand.total_contributions[i] += difference;
-			message["amount"] = difference.into();					
-			player.money -= difference;
-			num_settled += 1;				
-		    }			    
-		}
-		PlayerAction::Bet(new_bet) => {
-		    let difference = new_bet - player_cumulative;
-		    println!("difference = {}", difference);
-		    player.money -= difference;
-		    current_bet = new_bet;
-		    cumulative_bets[i] += difference;
-		    println!("sup {:?}", player);
-		    gamehand.total_contributions[i] += difference;
-		    let all_in = if player.is_all_in() {
-			println!("Just bet the rest of our money!");
-			num_all_in += 1;
-			num_settled = 0;
-			true
-		    } else {
-			num_settled = 1;
-			false
-		    };
-		    gamehand.pot_manager.contribute(player.id, difference, all_in);
-		    message["action"] = "bet".into();
-		    message["amount"] = new_bet.into();
-		}
-	    }
-	    message["money"] = player.money.into();
-	    message["pots"] = gamehand.pot_manager.simple_repr().into();
-	    message["is_active"] = player.is_active.into();
-	    message["street_contributions"] = cumulative_bets[i].into();
-	    message["current_bet"] = current_bet.into();		    		    
-	    
-	    println!("{}", message.dump());
-	    PlayerConfig::send_group_message(
-		&message.dump(),
-		&self.player_ids_to_configs
-	    );
-	}
-	true // we can't actually get to this line
+            let action =
+                self.get_and_validate_action(&player, current_bet, player_cumulative, gamehand);
+
+            let mut message = object! {
+            msg_type: "player_action".to_owned(),
+            index: i,
+            player_name: name
+            };
+
+            // now that we have gotten the current player's action and handled
+            // any meta actions, we are free to respond and mutate the player
+            // so we re-borrow it as mutable
+            let player = self.players[i].as_mut().unwrap();
+            match action {
+                PlayerAction::PostSmallBlind(amount) => {
+                    message["action"] = "small blind".into();
+                    message["amount"] = amount.into();
+                    cumulative_bets[i] += amount;
+                    gamehand.total_contributions[i] += amount;
+                    player.money -= amount;
+                    // regardless if the player couldn't afford it, the new street bet is the big blind
+                    current_bet = self.small_blind;
+                    let all_in = if player.is_all_in() {
+                        num_all_in += 1;
+                        true
+                    } else {
+                        false
+                    };
+                    gamehand.pot_manager.contribute(player.id, amount, all_in);
+                }
+                PlayerAction::PostBigBlind(amount) => {
+                    message["action"] = "big blind".into();
+                    message["amount"] = amount.into();
+                    cumulative_bets[i] += amount;
+                    gamehand.total_contributions[i] += amount;
+                    player.money -= amount;
+                    // regardless if the player couldn't afford it, the new street bet is the big blind
+                    current_bet = self.big_blind;
+                    let all_in = if player.is_all_in() {
+                        num_all_in += 1;
+                        true
+                    } else {
+                        false
+                    };
+                    gamehand.pot_manager.contribute(player.id, amount, all_in);
+                    // note: we dont count the big blind as a "settled" player,
+                    // since they still get a chance to act after the small blind
+                }
+                PlayerAction::Fold => {
+                    message["action"] = "fold".into();
+                    player.deactivate();
+                    num_active -= 1;
+                }
+                PlayerAction::Check => {
+                    message["action"] = "check".into();
+                    num_settled += 1;
+                }
+                PlayerAction::Call => {
+                    message["action"] = "call".into();
+                    let difference = current_bet - player_cumulative;
+                    if difference >= player.money {
+                        println!("you have to put in the rest of your chips");
+                        gamehand
+                            .pot_manager
+                            .contribute(player.id, player.money, true);
+                        cumulative_bets[i] += player.money;
+                        gamehand.total_contributions[i] += player.money;
+                        message["amount"] = player.money.into();
+                        player.money = 0;
+                        num_all_in += 1;
+                    } else {
+                        gamehand
+                            .pot_manager
+                            .contribute(player.id, difference, false);
+                        cumulative_bets[i] += difference;
+                        gamehand.total_contributions[i] += difference;
+                        message["amount"] = difference.into();
+                        player.money -= difference;
+                        num_settled += 1;
+                    }
+                }
+                PlayerAction::Bet(new_bet) => {
+                    let difference = new_bet - player_cumulative;
+                    println!("difference = {}", difference);
+                    player.money -= difference;
+                    current_bet = new_bet;
+                    cumulative_bets[i] += difference;
+                    println!("sup {:?}", player);
+                    gamehand.total_contributions[i] += difference;
+                    let all_in = if player.is_all_in() {
+                        println!("Just bet the rest of our money!");
+                        num_all_in += 1;
+                        num_settled = 0;
+                        true
+                    } else {
+                        num_settled = 1;
+                        false
+                    };
+                    gamehand
+                        .pot_manager
+                        .contribute(player.id, difference, all_in);
+                    message["action"] = "bet".into();
+                    message["amount"] = new_bet.into();
+                }
+            }
+            message["money"] = player.money.into();
+            message["pots"] = gamehand.pot_manager.simple_repr().into();
+            message["is_active"] = player.is_active.into();
+            message["street_contributions"] = cumulative_bets[i].into();
+            message["current_bet"] = current_bet.into();
+
+            println!("{}", message.dump());
+            PlayerConfig::send_group_message(&message.dump(), &self.player_ids_to_configs);
+        }
+        true // we can't actually get to this line
     }
 
     /// if the player is a human, then we look for their action in the incoming_actions hashmap
     /// this value is set by the game hub when handling a message from a player client
-    fn get_action_from_player(
-	&self, 
-	player: &Player) -> Option<PlayerAction> {
+    fn get_action_from_player(&self, player: &Player) -> Option<PlayerAction> {
         if player.human_controlled {
-	    let mut actions = self.incoming_actions.unwrap().lock().unwrap();	    
-	    println!("incoming_actions = {:?}", actions);	    
+            let mut actions = self.incoming_actions.unwrap().lock().unwrap();
+            println!("incoming_actions = {:?}", actions);
             if let Some(action) = actions.get_mut(&player.id) {
-                println!(
-                    "Player: {:?} has action {:?}",
-                    player.id, action
-                );
-		let value = *action;
-		actions.remove(&player.id);  // wipe this action so we don't repeat it next time
+                println!("Player: {:?} has action {:?}", player.id, action);
+                let value = *action;
+                actions.remove(&player.id); // wipe this action so we don't repeat it next time
                 Some(value)
             } else {
                 None
@@ -795,7 +795,7 @@ impl <'a> Game {
                         // just go all in if we are at 10% starting
                         player.money
                     } else {
-                        rand::thread_rng().gen_range(1..player.money/2 as u32)
+                        rand::thread_rng().gen_range(1..player.money / 2 as u32)
                     };
                     Some(PlayerAction::Bet(amount))
                 }
@@ -803,96 +803,90 @@ impl <'a> Game {
             }
         }
     }
-	
-    fn get_and_validate_action(	
-	&self, 
+
+    fn get_and_validate_action(
+        &mut self,
         player: &Player,
         current_bet: u32,
         player_cumulative: u32,
-	mut gamehand: GameHand,
+        gamehand: &mut GameHand,
     ) -> PlayerAction {
         // if it isnt valid based on the current bet and the amount the player has already contributed,
         // then it loops
         // position is our spot in the order, with 0 == small blind, etc
 
-	// we sleep a little bit each time so that the output doesnt flood the user at one moment
-        let pause_duration = time::Duration::from_secs(1); 	
+        // we sleep a little bit each time so that the output doesnt flood the user at one moment
+        let pause_duration = time::Duration::from_secs(1);
         thread::sleep(pause_duration);
-	
+
         if gamehand.street == Street::Preflop && current_bet == 0 {
             // collect small blind!
-            return PlayerAction::PostSmallBlind(cmp::min(
-                self.small_blind,
-                player.money,
-            ));
+            return PlayerAction::PostSmallBlind(cmp::min(self.small_blind, player.money));
         } else if gamehand.street == Street::Preflop && current_bet == self.small_blind {
             // collect big blind!
-            return PlayerAction::PostBigBlind(
-                cmp::min(self.big_blind, player.money),
-            );
+            return PlayerAction::PostBigBlind(cmp::min(self.big_blind, player.money));
         }
         let prompt = if current_bet > player_cumulative {
-	    let diff = current_bet - player_cumulative;
-	    format!("Enter action ({} to call): ", diff)
-	} else {
-	    format!("Enter action (current bet = {}): ", current_bet)	    
-	};
-	let message = object!{
-	    msg_type: "prompt".to_owned(),
-	    prompt: prompt,
-	};
-	PlayerConfig::send_specific_message(
-	    &message.dump(),
-	    player.id,
-	    &self.player_ids_to_configs,
-	);			    			    
-		
+            let diff = current_bet - player_cumulative;
+            format!("Enter action ({} to call): ", diff)
+        } else {
+            format!("Enter action (current bet = {}): ", current_bet)
+        };
+        let message = object! {
+            msg_type: "prompt".to_owned(),
+            prompt: prompt,
+        };
+        PlayerConfig::send_specific_message(
+            &message.dump(),
+            player.id,
+            &self.player_ids_to_configs,
+        );
+
         let mut action = None;
         let mut attempts = 0;
         let retry_duration = time::Duration::from_secs(1); // how long to wait between trying again
         while attempts < 10000 && action.is_none() {
+            // the first thing we do on each loop is handle meta action
+            // this lets us display messages in real-time without having to wait until after the
+            // current player gives their action
+            self.handle_meta_actions();
 
-	    // the first thing we do on each loop is handle meta action
-	    // this lets us display messages in real-time without having to wait until after the
-	    // current player gives their action
-	    self.handle_meta_actions();
-	    
             if player.human_controlled {
                 // we don't need to count the attempts at getting a response from a computer
                 // TODO: the computer can give a better than random guess at a move
                 // Currently it might try to check when it has to call for example,
                 attempts += 1;
             }
-	    if player.is_sitting_out {
-		println!("player is sitting out, so fold");
-		action = Some(PlayerAction::Fold);
-		break;
-	    }
-	    if !self.player_ids_to_configs.contains_key(&player.id) {
-		// the config no longer exists for this player, so they must have left
-		println!("player config no longer exists, so the player must have left");
-		action = Some(PlayerAction::Fold);
-		break;		
-	    }
-	    
+            if player.is_sitting_out {
+                println!("player is sitting out, so fold");
+                action = Some(PlayerAction::Fold);
+                break;
+            }
+            if !self.player_ids_to_configs.contains_key(&player.id) {
+                // the config no longer exists for this player, so they must have left
+                println!("player config no longer exists, so the player must have left");
+                action = Some(PlayerAction::Fold);
+                break;
+            }
+
             println!("Attempting to get player action on attempt {:?}", attempts);
             match self.get_action_from_player(player) {
-		None => {
+                None => {
                     // println!("No action is set for the player {:?}", player.id);
                     // we give the user a second to place their action
                     thread::sleep(retry_duration);
-		}
-		
+                }
+
                 Some(PlayerAction::Fold) => {
                     if current_bet <= player_cumulative {
                         // if the player has put in enough then no sense folding
                         if player.human_controlled {
                             println!("you said fold but we will let you check!");
-			    PlayerConfig::send_specific_message(			    
-				&"You said fold but we will let you check!".to_owned(),
-				player.id,
-				&self.player_ids_to_configs
-			    );			    
+                            PlayerConfig::send_specific_message(
+                                &"You said fold but we will let you check!".to_owned(),
+                                player.id,
+                                &self.player_ids_to_configs,
+                            );
                         }
                         action = Some(PlayerAction::Check);
                     } else {
@@ -904,11 +898,11 @@ impl <'a> Game {
                     if current_bet > player_cumulative {
                         // if the current bet is higher than this player's bet
                         if player.human_controlled {
-			    PlayerConfig::send_specific_message(
-				&"You can't check since there is a bet!!".to_owned(),
-				player.id,
-				&self.player_ids_to_configs
-			    );
+                            PlayerConfig::send_specific_message(
+                                &"You can't check since there is a bet!!".to_owned(),
+                                player.id,
+                                &self.player_ids_to_configs,
+                            );
                         }
                         continue;
                     }
@@ -920,17 +914,17 @@ impl <'a> Game {
                             // if the street bet isn't 0 then this makes no sense
                             println!("should we even be here???!");
                         }
-			// we can let them check
-			PlayerConfig::send_specific_message(
-			    &"There is nothing for you to call!!".to_owned(),
-			    player.id,
-			    &self.player_ids_to_configs
-			);
-			
-                        action = Some(PlayerAction::Check);			
+                        // we can let them check
+                        PlayerConfig::send_specific_message(
+                            &"There is nothing for you to call!!".to_owned(),
+                            player.id,
+                            &self.player_ids_to_configs,
+                        );
+
+                        action = Some(PlayerAction::Check);
                     } else {
-			action = Some(PlayerAction::Call);
-		    }
+                        action = Some(PlayerAction::Call);
+                    }
                 }
                 Some(PlayerAction::Bet(new_bet)) => {
                     if current_bet < player_cumulative {
@@ -938,39 +932,38 @@ impl <'a> Game {
                         println!("this should not happen!");
                         continue;
                     }
-		    // TODO: this line blew up
-		    // thread '<unnamed>' panicked at 'attempt to subtract with overflow', src/logic/game.rs:738:24
-		    // note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+                    // TODO: this line blew up
+                    // thread '<unnamed>' panicked at 'attempt to subtract with overflow', src/logic/game.rs:738:24
+                    // note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
                     // I think we need to change the money amounts to be signed
-		    // OR it might be better to look into/fix the bet logic
-		    // like should new_bet just be a standalone thing above the current bet?
-		    // do we need to add raising?
+                    // OR it might be better to look into/fix the bet logic
+                    // like should new_bet just be a standalone thing above the current bet?
+                    // do we need to add raising?
 
-		    // NOTE ---> I changed it now
+                    // NOTE ---> I changed it now
                     if new_bet > player.money + player_cumulative {
-			println!("cant bet more than you have");
-			PlayerConfig::send_specific_message(
-			    &"You can't bet more than you have!!".to_owned(),
-			    player.id,
-			    &self.player_ids_to_configs
-			);
+                        println!("cant bet more than you have");
+                        PlayerConfig::send_specific_message(
+                            &"You can't bet more than you have!!".to_owned(),
+                            player.id,
+                            &self.player_ids_to_configs,
+                        );
                         continue;
                     }
                     if new_bet <= current_bet {
-			println!("new bet must be larger than current");
-			PlayerConfig::send_specific_message(
-			    &"the new bet has to be larger than the current bet!".to_owned(),
-			    player.id,
-			    &self.player_ids_to_configs
-			);
+                        println!("new bet must be larger than current");
+                        PlayerConfig::send_specific_message(
+                            &"the new bet has to be larger than the current bet!".to_owned(),
+                            player.id,
+                            &self.player_ids_to_configs,
+                        );
                         continue;
                     }
                     action = Some(PlayerAction::Bet(new_bet));
                 }
-		other => {
-		    action = other;
-		}
-		
+                other => {
+                    action = other;
+                }
             }
         }
         // if we got a valid action, then we can return it,
@@ -986,13 +979,13 @@ impl <'a> Game {
 #[derive(Debug)]
 pub struct Game<'a> {
     hub_addr: Option<Addr<GameHub>>, // needs to be able to communicate back to the hub sometimes
-    incoming_actions: Option<&'a Arc<Mutex<HashMap<Uuid, PlayerAction>>>>,
-    incoming_meta_actions: Option<&'a Arc<Mutex<VecDeque<MetaAction>>>>,	
+    incoming_actions: Option<&'a Mutex<HashMap<Uuid, PlayerAction>>>,
+    incoming_meta_actions: Option<&'a Mutex<VecDeque<MetaAction>>>,
     pub name: String,
     deck: Box<dyn Deck>,
     players: [Option<Player>; 9], // 9 spots where players can sit
     player_ids_to_configs: HashMap<Uuid, PlayerConfig>,
-    max_players: u8, // how many will we let in the game    
+    max_players: u8,   // how many will we let in the game
     button_idx: usize, // index of the player with the button
     small_blind: u32,
     big_blind: u32,
@@ -1005,22 +998,21 @@ pub struct Game<'a> {
 impl<'a> Default for Game<'a> {
     fn default() -> Self {
         Self {
-	    hub_addr: None,
-	    incoming_actions: None,
-	    incoming_meta_actions: None,
-	    name: "Game".to_owned(),
+            hub_addr: None,
+            incoming_actions: None,
+            incoming_meta_actions: None,
+            name: "Game".to_owned(),
             deck: Box::new(StandardDeck::new()),
             players: Default::default(),
-	    player_ids_to_configs: HashMap::<Uuid, PlayerConfig>::new(),	    
-	    max_players: 9,
-	    button_idx: 0,
-	    small_blind: 4,
-	    big_blind: 8,
-	    buy_in: 1000,
-	    is_private: true,
-	    password: None,
+            player_ids_to_configs: HashMap::<Uuid, PlayerConfig>::new(),
+            max_players: 9,
+            button_idx: 0,
+            small_blind: 4,
+            big_blind: 8,
+            buy_in: 1000,
+            is_private: true,
+            password: None,
         }
-	
     }
 }
 
@@ -1028,38 +1020,38 @@ impl<'a> Game<'a> {
     /// the address of the GameHub is optional so that unit tests need not worry about it
     /// We can pass in a custom Deck object, but if not, we will just construct a StandardDeck
     pub fn new(
-	hub_addr: Addr<GameHub>,
-	incoming_actions: &Arc<Mutex<HashMap<Uuid, PlayerAction>>>,
-	incoming_meta_actions: &Arc<Mutex<VecDeque<MetaAction>>>,	
-	name: String,
-	deck_opt: Option<Box<dyn Deck>>,
-	max_players: u8, // how many will we let in the game    
-	small_blind: u32,
-	big_blind: u32,
-	buy_in: u32,
-	is_private: bool, // will it show up in the list of games
-	password: Option<String>,
+        hub_addr: Addr<GameHub>,
+        incoming_actions: &'a Mutex<HashMap<Uuid, PlayerAction>>,
+        incoming_meta_actions: &'a Mutex<VecDeque<MetaAction>>,
+        name: String,
+        deck_opt: Option<Box<dyn Deck>>,
+        max_players: u8, // how many will we let in the game
+        small_blind: u32,
+        big_blind: u32,
+        buy_in: u32,
+        is_private: bool, // will it show up in the list of games
+        password: Option<String>,
     ) -> Self {
-	let deck = if deck_opt.is_some() {
-	    deck_opt.unwrap()
-	} else {
-	    Box::new(StandardDeck::new())
-	};
+        let deck = if deck_opt.is_some() {
+            deck_opt.unwrap()
+        } else {
+            Box::new(StandardDeck::new())
+        };
         Game {
-	    hub_addr: Some(hub_addr),
-	    incoming_actions: Some(incoming_actions),
-	    incoming_meta_actions: Some(incoming_meta_actions),
-	    name,
+            hub_addr: Some(hub_addr),
+            incoming_actions: Some(incoming_actions),
+            incoming_meta_actions: Some(incoming_meta_actions),
+            name,
             deck,
             players: Default::default(),
-	    player_ids_to_configs: HashMap::<Uuid, PlayerConfig>::new(),	    
-	    max_players,
-	    button_idx: 0,
-	    small_blind,
-	    big_blind,
-	    buy_in,
-	    is_private,
-	    password,
+            player_ids_to_configs: HashMap::<Uuid, PlayerConfig>::new(),
+            max_players,
+            button_idx: 0,
+            small_blind,
+            big_blind,
+            buy_in,
+            is_private,
+            password,
         }
     }
 
@@ -1067,206 +1059,207 @@ impl<'a> Game<'a> {
     /// TODO: eventually we wanmt the player to select an open seat I guess
     /// returns the index of the seat that they joined (if they were able to join)
     pub fn add_user(&mut self, player_config: PlayerConfig) -> Option<usize> {
-	let new_player = Player::new(player_config.id, true, self.buy_in);
-	self.add_player(player_config, new_player)
+        let new_player = Player::new(player_config.id, true, self.buy_in);
+        self.add_player(player_config, new_player)
     }
 
     pub fn add_bot(&mut self, name: String) -> Option<usize> {
-	let new_bot = Player::new_bot(self.buy_in);
-	let new_config = PlayerConfig::new(new_bot.id, Some(name), None);
-	self.add_player(new_config, new_bot)
+        let new_bot = Player::new_bot(self.buy_in);
+        let new_config = PlayerConfig::new(new_bot.id, Some(name), None);
+        self.add_player(new_config, new_bot)
     }
-    
-    fn add_player(
-	&mut self,
-	player_config: PlayerConfig,
-	player: Player,
-    ) -> Option<usize> {
-	let mut index = None;
-	for (i, player_spot) in self.players.iter_mut().enumerate() {
-	    if player_spot.is_none() {
-		let id = player_config.id; // copy the id for sending a message after we add the config
-		*player_spot = Some(player);
-		self.player_ids_to_configs.insert(player_config.id, player_config);
-		index = Some(i);
-		println!("Joining game at index: {}", i);
-		let message = object!{
-		    msg_type: "joined_game".to_owned(),
-		    index: i,
-		};
-		PlayerConfig::send_specific_message(
-		    &message.dump(),
-		    id,
-		    &self.player_ids_to_configs,
-		);			    			    
-		break;
-	    }
-	}
-	for (i, player_spot) in self.players.iter().enumerate() {
-	    // display the play positions for the front end to consume
-	    if let Some(player) = player_spot {
-		let mut message = object!{
-		    msg_type: "player_info".to_owned(),
-		    index: i,
-		};
-		let config = self.player_ids_to_configs.get(&player.id).unwrap();
-		let name = config.name.as_ref().unwrap().clone();
-		message["player_name"] = name.into();
-		message["money"] = player.money.into();
-		message["is_active"] = player.is_active.into();
-		PlayerConfig::send_group_message(&message.dump(),
-						 &self.player_ids_to_configs);			
-	    } 
-	}
-	index
+
+    fn add_player(&mut self, player_config: PlayerConfig, player: Player) -> Option<usize> {
+        let mut index = None;
+        if self.players.iter().flatten().count() >= self.max_players.into() {
+            // we already have as many as we can fit in the game
+            return index;
+        }
+        for (i, player_spot) in self.players.iter_mut().enumerate() {
+            if player_spot.is_none() {
+                let id = player_config.id; // copy the id for sending a message after we add the config
+                *player_spot = Some(player);
+                self.player_ids_to_configs
+                    .insert(player_config.id, player_config);
+                index = Some(i);
+                println!("Joining game at index: {}", i);
+                let message = object! {
+                    msg_type: "joined_game".to_owned(),
+                    index: i,
+                };
+                PlayerConfig::send_specific_message(
+                    &message.dump(),
+                    id,
+                    &self.player_ids_to_configs,
+                );
+                break;
+            }
+        }
+        for (i, player_spot) in self.players.iter().enumerate() {
+            // display the play positions for the front end to consume
+            if let Some(player) = player_spot {
+                let mut message = object! {
+                    msg_type: "player_info".to_owned(),
+                    index: i,
+                };
+                let config = self.player_ids_to_configs.get(&player.id).unwrap();
+                let name = config.name.as_ref().unwrap().clone();
+                message["player_name"] = name.into();
+                message["money"] = player.money.into();
+                message["is_active"] = player.is_active.into();
+                PlayerConfig::send_group_message(&message.dump(), &self.player_ids_to_configs);
+            }
+        }
+        index
     }
-                
+
     pub fn play(
-	&mut self,
-	hand_limit: Option<u32>, // how many hands total should be play? None == no limit
+        &mut self,
+        hand_limit: Option<u32>, // how many hands total should be play? None == no limit
     ) {
         let mut hand_count = 0;
         loop {
             hand_count += 1;
-	    if let Some(limit) = hand_limit {
-		if hand_count > limit {
-		    println!("hand limit has been reached");
-		    break;
-		}
-	    }	    
-            println!("\n\n\nPlaying hand {}, button_idx = {}", hand_count, self.button_idx);
-	    let message = object!{
-		msg_type: "new_hand".to_owned(),
-		hand_num: hand_count,
-		button_index: self.button_idx,
-	    };
-	    PlayerConfig::send_group_message(
-		&message.dump(),
-		&self.player_ids_to_configs);			
+            if let Some(limit) = hand_limit {
+                if hand_count > limit {
+                    println!("hand limit has been reached");
+                    break;
+                }
+            }
+            println!(
+                "\n\n\nPlaying hand {}, button_idx = {}",
+                hand_count, self.button_idx
+            );
+            let message = object! {
+            msg_type: "new_hand".to_owned(),
+            hand_num: hand_count,
+            button_index: self.button_idx,
+            };
+            PlayerConfig::send_group_message(&message.dump(), &self.player_ids_to_configs);
 
             self.play_one_hand();
 
-	    // check if any player is now missing from the config mapping,
-	    // this implies that the player left mid-hand, so they should fully be removed from the game
-	    for player_spot in self.players.iter_mut() {
-		if let Some(player) = player_spot {
-		    if !self.player_ids_to_configs.contains_key(&player.id) {
-			// the player is no more
-			println!("removing player {:?} since no longer in the config between hands", player);
-			*player_spot = None;
-		    }
-		}
-	    }
-	    self.handle_meta_actions();
-	    // attempt to set the next button
-	    self.button_idx = self.find_next_button().expect("we could not find a valid button index!");
+            // check if any player is now missing from the config mapping,
+            // this implies that the player left mid-hand, so they should fully be removed from the game
+            for player_spot in self.players.iter_mut() {
+                if let Some(player) = player_spot {
+                    if !self.player_ids_to_configs.contains_key(&player.id) {
+                        // the player is no more
+                        println!(
+                            "removing player {:?} since no longer in the config between hands",
+                            player
+                        );
+                        *player_spot = None;
+                    }
+                }
+            }
+            self.handle_meta_actions();
+            // attempt to set the next button
+            self.button_idx = self
+                .find_next_button()
+                .expect("we could not find a valid button index!");
         }
     }
 
     /// move the button to the next Player who is not sitting out
     /// if non can be found, then return false
     fn find_next_button(&mut self) -> Result<usize, &'static str> {
-	for i in (self.button_idx+1..9).chain(0..self.button_idx+1) {
-            //self.button_idx += 1; 
-	    //self.button_idx %= 9; // loop back to 0 if we reach the end
-	    println!("checking for next button at index {}", i);
-	    let button_spot = &mut self.players[i];
-	    if let Some(button_player) = button_spot {
+        for i in (self.button_idx + 1..9).chain(0..self.button_idx + 1) {
+            //self.button_idx += 1;
+            //self.button_idx %= 9; // loop back to 0 if we reach the end
+            println!("checking for next button at index {}", i);
+            let button_spot = &mut self.players[i];
+            if let Some(button_player) = button_spot {
                 if button_player.is_sitting_out {
-		    println!(
-                        "Player at index {} is sitting out so cannot be the button", i
-		    );
+                    println!(
+                        "Player at index {} is sitting out so cannot be the button",
+                        i
+                    );
                 } else if button_player.money == 0 {
-		    println!(
-                        "Player at index {} has no money so cannot be the button", i
-		    );
-		} else {
-		    // We found a player who is not sitting out, so it is a valid
-		    // button position
-		    println!("found the button!");
-		    return Ok(i);
-		}
+                    println!("Player at index {} has no money so cannot be the button", i);
+                } else {
+                    // We found a player who is not sitting out, so it is a valid
+                    // button position
+                    println!("found the button!");
+                    return Ok(i);
+                }
             }
         }
-	Err("could not find a valid button")
+        Err("could not find a valid button")
     }
-    
-    fn handle_meta_actions(&mut self ) {
-	let mut meta_actions = self.incoming_meta_actions.unwrap().lock().unwrap();
-	for _ in 0..meta_actions.len() {
-	    match meta_actions.pop_front().unwrap() {
-		MetaAction::Chat(id, text) => {
-		    // send the message to all players,
-		    // appended by the player name
-		    println!("chat message inside the game hand wow!");
-		    
-		    let name = &self.player_ids_to_configs.get(&id).unwrap().name;
-		    let message = object!{
-			msg_type: "chat".to_owned(),
-			player_name: name.clone(),
-			text: text,
-		    };
 
-		    PlayerConfig::send_group_message(&message.dump(),
-						     &self.player_ids_to_configs);			
-		},
-		MetaAction::Join(player_config) => {
-		    // add a new player to the game
-		    let id = player_config.id; // copy the id so we can use to send a message later
-		    if self.add_user(
-			player_config,
-		    ).is_none()
-		    {
-			// we were unable to add the player
-			PlayerConfig::send_specific_message(
-			    &"Unable to join game, it must be full!".to_owned(),
-			    id,
-			    &self.player_ids_to_configs,
-			);
-		    }
-		},
-		MetaAction::Leave(id) => {
-		    println!("handling leave meta action");
-		    let config = self.player_ids_to_configs.remove(&id).unwrap();
-		    PlayerConfig::send_group_message(&format!("{:?} has left the game", config.name),
-		    				     &self.player_ids_to_configs);
-		    if let Some(hub_addr) = self.hub_addr {
-			// tell the hub that we left			
-			hub_addr.do_send(Removed{config});
-		    }
-		},
-		MetaAction::PlayerName(id, new_name) => {
-		    PlayerConfig::set_player_name(id, &new_name, &mut self.player_ids_to_configs);
-		},
-		MetaAction::SitOut(id) => {
-		    for player in self.players.iter_mut().flatten() {
-			if player.id == id {
-			    println!("player {} being set to is_sitting_out = true", id);	    
-			    player.is_sitting_out = true;
-			}
-		    }
-		},
-		MetaAction::ImBack(id) => {
-		    for player in self.players.iter_mut().flatten() {
-			if player.id == id {
-			    println!("player {} being set to is_sitting_out = false", id);
-			    player.is_sitting_out = false;
-			}
-		    }
-		    
-		},
-	    }
-	}
+    fn handle_meta_actions(&mut self) {
+        let mut meta_actions = self.incoming_meta_actions.unwrap().lock().unwrap();
+        for _ in 0..meta_actions.len() {
+            match meta_actions.pop_front().unwrap() {
+                MetaAction::Chat(id, text) => {
+                    // send the message to all players,
+                    // appended by the player name
+                    println!("chat message inside the game hand wow!");
+
+                    let name = &self.player_ids_to_configs.get(&id).unwrap().name;
+                    let message = object! {
+                    msg_type: "chat".to_owned(),
+                    player_name: name.clone(),
+                    text: text,
+                    };
+
+                    PlayerConfig::send_group_message(&message.dump(), &self.player_ids_to_configs);
+                }
+                MetaAction::Join(player_config) => {
+                    // add a new player to the game
+                    let id = player_config.id; // copy the id so we can use to send a message later
+                    if self.add_user(player_config).is_none() {
+                        // we were unable to add the player
+                        PlayerConfig::send_specific_message(
+                            &"Unable to join game, it must be full!".to_owned(),
+                            id,
+                            &self.player_ids_to_configs,
+                        );
+                    }
+                }
+                MetaAction::Leave(id) => {
+                    println!("handling leave meta action");
+                    let config = self.player_ids_to_configs.remove(&id).unwrap();
+                    PlayerConfig::send_group_message(
+                        &format!("{:?} has left the game", config.name),
+                        &self.player_ids_to_configs,
+                    );
+                    if let Some(hub_addr) = &self.hub_addr {
+                        // tell the hub that we left
+                        hub_addr.do_send(Removed { config });
+                    }
+                }
+                MetaAction::PlayerName(id, new_name) => {
+                    PlayerConfig::set_player_name(id, &new_name, &mut self.player_ids_to_configs);
+                }
+                MetaAction::SitOut(id) => {
+                    for player in self.players.iter_mut().flatten() {
+                        if player.id == id {
+                            println!("player {} being set to is_sitting_out = true", id);
+                            player.is_sitting_out = true;
+                        }
+                    }
+                }
+                MetaAction::ImBack(id) => {
+                    for player in self.players.iter_mut().flatten() {
+                        if player.id == id {
+                            println!("player {} being set to is_sitting_out = false", id);
+                            player.is_sitting_out = false;
+                        }
+                    }
+                }
+            }
+        }
     }
-    
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::logic::card::{Card, Suit, Rank, RiggedDeck};
-    use std::collections::{HashMap};
-    
+    use crate::logic::card::{Card, Rank, RiggedDeck, Suit};
+    use std::collections::HashMap;
+
     #[test]
     fn add_bot() {
         let mut game = Game::default();
@@ -1274,12 +1267,12 @@ mod tests {
         let index = game.add_bot(name);
         assert_eq!(index.unwrap(), 0); // the first position to be added to is index 0
         assert_eq!(game.players.len(), 9);
-	// flatten to get all the Some() players
-	let some_players = game.players.iter().flatten().count();
+        // flatten to get all the Some() players
+        let some_players = game.players.iter().flatten().count();
         assert_eq!(some_players, 1);
         assert!(!game.players[0].as_ref().unwrap().human_controlled);
     }
-    
+
     #[test]
     fn add_user_no_connection() {
         let mut game = Game::default();
@@ -1288,8 +1281,8 @@ mod tests {
         let settings = PlayerConfig::new(id, Some(name), None);
         game.add_user(settings);
         assert_eq!(game.players.len(), 9);
-	// flatten to get all the Some() players
-	let some_players = game.players.iter().flatten().count();
+        // flatten to get all the Some() players
+        let some_players = game.players.iter().flatten().count();
         assert_eq!(some_players, 1);
         assert!(game.players[0].as_ref().unwrap().human_controlled);
     }
@@ -1299,188 +1292,192 @@ mod tests {
     #[test]
     fn max_players_in_game_() {
         let mut game = Game::default();
-       let max_players = 3;
-       game.max_players = max_players;
+        let max_players = 3;
+        game.max_players = max_players;
 
-       // we TRY to add 5 bots
-       for i in 0..5 {
+        // we TRY to add 5 bots
+        for i in 0..5 {
             let name = format!("Bot {}", i);
             let index = game.add_bot(name);
-           if i < max_players {
-               assert_eq!(index.unwrap() as u8, i);
-           } else {
-               // above max_players, the returned index should be None
-               // i.e. the player was not added to the game
-               assert_eq!(index, None);
-           }
-       }
+            if i < max_players {
+                assert_eq!(index.unwrap() as u8, i);
+            } else {
+                // above max_players, the returned index should be None
+                // i.e. the player was not added to the game
+                assert_eq!(index, None);
+            }
+        }
         assert_eq!(game.players.len(), 9); // len of players always simply 9
-       
-       // flatten to get all the Some() players
-       let some_players = game.players.iter().flatten().count();
-       // but only max_players players are in the game at the end      
+
+        // flatten to get all the Some() players
+        let some_players = game.players.iter().flatten().count();
+        // but only max_players players are in the game at the end
         assert_eq!(some_players as u8, max_players);
-       
     }
-    
+
     /// the small blind folds, so the big blind should win and get paid
     #[test]
     fn instant_fold() {
         let mut game = Game::default();
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	game.incoming_actions = Some(&incoming_actions);
-	game.incoming_meta_actions = Some(&incoming_meta_actions);
+        let incoming_actions = Mutex::new(HashMap::<Uuid, PlayerAction>::new());
+        let incoming_meta_actions = Mutex::new(VecDeque::<MetaAction>::new());
+        game.incoming_actions = Some(&incoming_actions);
+        game.incoming_meta_actions = Some(&incoming_meta_actions);
 
-	// player1 will start as the button
-	let id1 = uuid::Uuid::new_v4();
+        // player1 will start as the button
+        let id1 = uuid::Uuid::new_v4();
         let name1 = "Human1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
         game.add_user(settings1);
 
-	// player2 will start as the small blind
-	let id2 = uuid::Uuid::new_v4();
+        // player2 will start as the small blind
+        let id2 = uuid::Uuid::new_v4();
         let name2 = "Human1".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
         game.add_user(settings2);
-	// flatten to get all the Some() players
-	let some_players = game.players.iter().flatten().count();
+        // flatten to get all the Some() players
+        let some_players = game.players.iter().flatten().count();
         assert_eq!(some_players, 2);
         assert!(game.players[0].as_ref().unwrap().human_controlled);
-	
-	let handler = thread::spawn( move || {
-	    game.play_one_hand();
-	    game // return the game back
-	});
-	
-	// set the action that player2 folds
-	incoming_actions.lock().unwrap().insert(id2, PlayerAction::Fold);
 
-	// get the game back from the thread
-	let game = handler.join().unwrap();
-	
-	// check that the money changed hands
-	assert_eq!(game.players[0].as_ref().unwrap().money, 1004);
-	assert_eq!(game.players[1].as_ref().unwrap().money, 996);	
+        let game = std::thread::scope(|scope| {
+            let handler = scope.spawn(move || {
+                game.play_one_hand();
+                game // return the game back
+            });
 
-	
+            // set the action that player2 folds
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id2, PlayerAction::Fold);
+
+            // get the game back from the thread
+            handler.join().unwrap()
+        });
+
+        // check that the money changed hands
+        assert_eq!(game.players[0].as_ref().unwrap().money, 1004);
+        assert_eq!(game.players[1].as_ref().unwrap().money, 996);
     }
-
 
     /// the small blind calls, the big blind checks to the flop
     /// the small blind bets on the flop, and the big blind folds
     #[test]
     fn call_check_bet_fold() {
         let mut game = Game::default();
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	game.incoming_actions = Some(&incoming_actions);
-	game.incoming_meta_actions = Some(&incoming_meta_actions);
+        let incoming_actions = Mutex::new(HashMap::<Uuid, PlayerAction>::new());
+        let incoming_meta_actions = Mutex::new(VecDeque::<MetaAction>::new());
+        game.incoming_actions = Some(&incoming_actions);
+        game.incoming_meta_actions = Some(&incoming_meta_actions);
 
-	// player1 will start as the button
-	let id1 = uuid::Uuid::new_v4();
+        // player1 will start as the button
+        let id1 = uuid::Uuid::new_v4();
         let name1 = "Human1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
         game.add_user(settings1);
 
-	// player2 will start as the small blind
-	let id2 = uuid::Uuid::new_v4();
+        // player2 will start as the small blind
+        let id2 = uuid::Uuid::new_v4();
         let name2 = "Human1".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
         game.add_user(settings2);
-	// flatten to get all the Some() players
-	let some_players = game.players.iter().flatten().count();
+        // flatten to get all the Some() players
+        let some_players = game.players.iter().flatten().count();
         assert_eq!(some_players, 2);
         assert!(game.players[0].as_ref().unwrap().human_controlled);
-	
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
 
+        let game = std::thread::scope(|scope| {
+            let handler = scope.spawn(move || {
+                game.play_one_hand();
+                game // return the game back
+            });
 
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	let handler = thread::spawn( move || {
-	    game.play_one_hand();
-	    game // return the game back
-	});
-	
-	// set the action that player2 calls
-	incoming_actions.lock().unwrap().insert(id2, PlayerAction::Call);
-	// player1 checks
-	incoming_actions.lock().unwrap().insert(id1, PlayerAction::Check);
+            // set the action that player2 calls
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id2, PlayerAction::Call);
+            // player1 checks
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id1, PlayerAction::Check);
 
+            // wait for the flop
+            let wait_duration = time::Duration::from_secs(7);
+            thread::sleep(wait_duration);
 
-	// wait for the flop
-        let wait_duration = time::Duration::from_secs(7);
-	std::thread::sleep(wait_duration);
+            // player2 bets on the flop
+            println!("now sending the flop actions");
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id2, PlayerAction::Bet(10));
+            // player1 folds
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id1, PlayerAction::Fold);
 
-	// player2 bets on the flop
-	println!("now sending the flop actions");	
-	incoming_actions.lock().unwrap().insert(id2, PlayerAction::Bet(10));
-	// player1 folds
-	incoming_actions.lock().unwrap().insert(id1, PlayerAction::Fold);
-	
-	// get the game back from the thread
-	let game = handler.join().unwrap();
-	
-	// check that the money changed hands
-	assert_eq!(game.players[0].as_ref().unwrap().money, 992);
-	assert_eq!(game.players[1].as_ref().unwrap().money, 1008);	
+            // get the game back from the thread
+            handler.join().unwrap()
+        });
+
+        // check that the money changed hands
+        assert_eq!(game.players[0].as_ref().unwrap().money, 992);
+        assert_eq!(game.players[1].as_ref().unwrap().money, 1008);
     }
 
     /// the small blind bets, the big blind folds
     #[test]
     fn pre_flop_bet_fold() {
         let mut game = Game::default();
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	game.incoming_actions = Some(&incoming_actions);
-	game.incoming_meta_actions = Some(&incoming_meta_actions);
+        let incoming_actions = Mutex::new(HashMap::<Uuid, PlayerAction>::new());
+        let incoming_meta_actions = Mutex::new(VecDeque::<MetaAction>::new());
+        game.incoming_actions = Some(&incoming_actions);
+        game.incoming_meta_actions = Some(&incoming_meta_actions);
 
-	// player1 will start as the button
-	let id1 = uuid::Uuid::new_v4();
+        // player1 will start as the button
+        let id1 = uuid::Uuid::new_v4();
         let name1 = "Human1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
         game.add_user(settings1);
 
-	// player2 will start as the small blind
-	let id2 = uuid::Uuid::new_v4();
+        // player2 will start as the small blind
+        let id2 = uuid::Uuid::new_v4();
         let name2 = "Human1".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
         game.add_user(settings2);
-	// flatten to get all the Some() players
-	let some_players = game.players.iter().flatten().count();
+        // flatten to get all the Some() players
+        let some_players = game.players.iter().flatten().count();
         assert_eq!(some_players, 2);
         assert!(game.players[0].as_ref().unwrap().human_controlled);
-	
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
 
+        let game = std::thread::scope(|scope| {
+            let handler = scope.spawn(move || {
+                game.play_one_hand();
+                game // return the game back
+            });
 
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	let handler = thread::spawn( move || {
-	    game.play_one_hand();
-	    game // return the game back
-	});
-	
-	// set the action that player2 bets
-	incoming_actions.lock().unwrap().insert(id2, PlayerAction::Bet(22));
-	// player1 folds
-	incoming_actions.lock().unwrap().insert(id1, PlayerAction::Fold);
-	
-	// get the game back from the thread
-	let game = handler.join().unwrap();
-	
-	// check that the money changed hands
-	assert_eq!(game.players[0].as_ref().unwrap().money, 992);
-	assert_eq!(game.players[1].as_ref().unwrap().money, 1008);	
+            // set the action that player2 bets
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id2, PlayerAction::Bet(22));
+            // player1 folds
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id1, PlayerAction::Fold);
+
+            // get the game back from the thread
+            handler.join().unwrap()
+        });
+
+        // check that the money changed hands
+        assert_eq!(game.players[0].as_ref().unwrap().money, 992);
+        assert_eq!(game.players[1].as_ref().unwrap().money, 1008);
     }
 
     /// the small blind bets, the big blind calls
@@ -1488,202 +1485,262 @@ mod tests {
     #[test]
     fn bet_call_bet_fold() {
         let mut game = Game::default();
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	game.incoming_actions = Some(&incoming_actions);
-	game.incoming_meta_actions = Some(&incoming_meta_actions);
+        let incoming_actions = Mutex::new(HashMap::<Uuid, PlayerAction>::new());
+        let incoming_meta_actions = Mutex::new(VecDeque::<MetaAction>::new());
+        game.incoming_actions = Some(&incoming_actions);
+        game.incoming_meta_actions = Some(&incoming_meta_actions);
 
-	// player1 will start as the button
-	let id1 = uuid::Uuid::new_v4();
+        // player1 will start as the button
+        let id1 = uuid::Uuid::new_v4();
         let name1 = "Human1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
         game.add_user(settings1);
 
-	// player2 will start as the small blind
-	let id2 = uuid::Uuid::new_v4();
+        // player2 will start as the small blind
+        let id2 = uuid::Uuid::new_v4();
         let name2 = "Human1".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
         game.add_user(settings2);
-	// flatten to get all the Some() players
-	let some_players = game.players.iter().flatten().count();
+        // flatten to get all the Some() players
+        let some_players = game.players.iter().flatten().count();
         assert_eq!(some_players, 2);
         assert!(game.players[0].as_ref().unwrap().human_controlled);
-	
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
 
+        let game = std::thread::scope(|scope| {
+            let handler = scope.spawn(move || {
+                game.play_one_hand();
+                game // return the game back
+            });
 
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	let handler = thread::spawn( move || {
-	    game.play_one_hand();
-	    game // return the game back
-	});
-	
-	// set the action that player2 bets
-	incoming_actions.lock().unwrap().insert(id2, PlayerAction::Bet(22));
-	// player1 calls
-	incoming_actions.lock().unwrap().insert(id1, PlayerAction::Call);
+            // set the action that player2 bets
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id2, PlayerAction::Bet(22));
+            // player1 calls
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id1, PlayerAction::Call);
 
-	// wait for the flop
-        let wait_duration = time::Duration::from_secs(7);
-	std::thread::sleep(wait_duration);
+            // wait for the flop
+            let wait_duration = time::Duration::from_secs(7);
+            thread::sleep(wait_duration);
 
-	// player2 bets on the flop
-	println!("now sending the flop actions");	
-	incoming_actions.lock().unwrap().insert(id2, PlayerAction::Bet(10));
-	// player1 folds
-	incoming_actions.lock().unwrap().insert(id1, PlayerAction::Fold);
-	
-	// get the game back from the thread
-	let game = handler.join().unwrap();
-	
-	// check that the money changed hands
-	assert_eq!(game.players[0].as_ref().unwrap().money, 978);
-	assert_eq!(game.players[1].as_ref().unwrap().money, 1022);	
+            // player2 bets on the flop
+            println!("now sending the flop actions");
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id2, PlayerAction::Bet(10));
+            // player1 folds
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id1, PlayerAction::Fold);
+
+            // get the game back from the thread
+            handler.join().unwrap()
+        });
+
+        // check that the money changed hands
+        assert_eq!(game.players[0].as_ref().unwrap().money, 978);
+        assert_eq!(game.players[1].as_ref().unwrap().money, 1022);
     }
 
     /// the small blind goes all in and the big blind calls
     #[test]
     fn all_in_call() {
-	let mut deck = RiggedDeck::new();
+        let mut deck = RiggedDeck::new();
 
-	// we want the button/big blind to lose for testing purposes
-	deck.push(Card{rank: Rank::Two, suit: Suit::Club});
-	deck.push(Card{rank: Rank::Three, suit: Suit::Club});	
+        // we want the button/big blind to lose for testing purposes
+        deck.push(Card {
+            rank: Rank::Two,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::Three,
+            suit: Suit::Club,
+        });
 
-	// now the small blind's hole cards
-	deck.push(Card{rank: Rank::Ten, suit: Suit::Club});
-	deck.push(Card{rank: Rank::Ten, suit: Suit::Heart});
-	
-	// now the full run out
-	deck.push(Card{rank: Rank::Ten, suit: Suit::Diamond});
-	deck.push(Card{rank: Rank::Ten, suit: Suit::Spade});	
-	deck.push(Card{rank: Rank::King, suit: Suit::Club});
-	deck.push(Card{rank: Rank::King, suit: Suit::Heart});	
-	deck.push(Card{rank: Rank::Queen, suit: Suit::Club});
+        // now the small blind's hole cards
+        deck.push(Card {
+            rank: Rank::Ten,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::Ten,
+            suit: Suit::Heart,
+        });
+
+        // now the full run out
+        deck.push(Card {
+            rank: Rank::Ten,
+            suit: Suit::Diamond,
+        });
+        deck.push(Card {
+            rank: Rank::Ten,
+            suit: Suit::Spade,
+        });
+        deck.push(Card {
+            rank: Rank::King,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::King,
+            suit: Suit::Heart,
+        });
+        deck.push(Card {
+            rank: Rank::Queen,
+            suit: Suit::Club,
+        });
 
         let mut game = Game::default();
-	game.deck = Box::new(deck);
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	game.incoming_actions = Some(&incoming_actions);
-	game.incoming_meta_actions = Some(&incoming_meta_actions);
-	
-	// player1 will start as the button
-	let id1 = uuid::Uuid::new_v4();
+        game.deck = Box::new(deck);
+        let incoming_actions = Mutex::new(HashMap::<Uuid, PlayerAction>::new());
+        let incoming_meta_actions = Mutex::new(VecDeque::<MetaAction>::new());
+        game.incoming_actions = Some(&incoming_actions);
+        game.incoming_meta_actions = Some(&incoming_meta_actions);
+
+        // player1 will start as the button
+        let id1 = uuid::Uuid::new_v4();
         let name1 = "Human1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
         game.add_user(settings1);
 
-	// player2 will start as the small blind
-	let id2 = uuid::Uuid::new_v4();
+        // player2 will start as the small blind
+        let id2 = uuid::Uuid::new_v4();
         let name2 = "Human1".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
         game.add_user(settings2);
-	// flatten to get all the Some() players
-	let some_players = game.players.iter().flatten().count();
+        // flatten to get all the Some() players
+        let some_players = game.players.iter().flatten().count();
         assert_eq!(some_players, 2);
         assert!(game.players[0].as_ref().unwrap().human_controlled);
-	
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
 
+        let game = std::thread::scope(|scope| {
+            let handler = scope.spawn(move || {
+                game.play_one_hand();
+                game // return the game back
+            });
 
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	let handler = thread::spawn( move || {
-	    game.play_one_hand();
-	    game // return the game back
-	});
-	
-	// set the action that player2 bets
-	incoming_actions.lock().unwrap().insert(id2, PlayerAction::Bet(1000));
-	// player1 calls
-	incoming_actions.lock().unwrap().insert(id1, PlayerAction::Call);
-	
-	// get the game back from the thread
-	let game = handler.join().unwrap();
-	
-	// the small blind won
-	assert_eq!(game.players[0].as_ref().unwrap().money, 0);
-	assert_eq!(game.players[1].as_ref().unwrap().money, 2000);
+            // set the action that player2 bets
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id2, PlayerAction::Bet(1000));
+            // player1 calls
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id1, PlayerAction::Call);
+
+            // get the game back from the thread
+            handler.join().unwrap()
+        });
+
+        // the small blind won
+        assert_eq!(game.players[0].as_ref().unwrap().money, 0);
+        assert_eq!(game.players[1].as_ref().unwrap().money, 2000);
     }
-    
+
     /// the small blind bets and the big blind calls
     /// this call makes the big blind go all-in
     #[test]
     fn call_all_in() {
-	let mut deck = RiggedDeck::new();
+        let mut deck = RiggedDeck::new();
 
-	// we want the button/big blind to lose for testing purposes
-	deck.push(Card{rank: Rank::Two, suit: Suit::Club});
-	deck.push(Card{rank: Rank::Three, suit: Suit::Club});	
+        // we want the button/big blind to lose for testing purposes
+        deck.push(Card {
+            rank: Rank::Two,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::Three,
+            suit: Suit::Club,
+        });
 
-	// now the small blind's hole cards
-	deck.push(Card{rank: Rank::Ten, suit: Suit::Club});
-	deck.push(Card{rank: Rank::Ten, suit: Suit::Heart});
-	
-	// now the full run out
-	deck.push(Card{rank: Rank::Ten, suit: Suit::Diamond});
-	deck.push(Card{rank: Rank::Ten, suit: Suit::Spade});	
-	deck.push(Card{rank: Rank::King, suit: Suit::Club});
-	deck.push(Card{rank: Rank::King, suit: Suit::Heart});	
-	deck.push(Card{rank: Rank::Queen, suit: Suit::Club});
+        // now the small blind's hole cards
+        deck.push(Card {
+            rank: Rank::Ten,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::Ten,
+            suit: Suit::Heart,
+        });
+
+        // now the full run out
+        deck.push(Card {
+            rank: Rank::Ten,
+            suit: Suit::Diamond,
+        });
+        deck.push(Card {
+            rank: Rank::Ten,
+            suit: Suit::Spade,
+        });
+        deck.push(Card {
+            rank: Rank::King,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::King,
+            suit: Suit::Heart,
+        });
+        deck.push(Card {
+            rank: Rank::Queen,
+            suit: Suit::Club,
+        });
 
         let mut game = Game::default();
-	game.deck = Box::new(deck);
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	game.incoming_actions = Some(&incoming_actions);
-	game.incoming_meta_actions = Some(&incoming_meta_actions);
-	
-	// player1 will start as the button
-	let id1 = uuid::Uuid::new_v4();
+        game.deck = Box::new(deck);
+        let incoming_actions = Mutex::new(HashMap::<Uuid, PlayerAction>::new());
+        let incoming_meta_actions = Mutex::new(VecDeque::<MetaAction>::new());
+        game.incoming_actions = Some(&incoming_actions);
+        game.incoming_meta_actions = Some(&incoming_meta_actions);
+
+        // player1 will start as the button
+        let id1 = uuid::Uuid::new_v4();
         let name1 = "Human1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
         game.add_user(settings1);
 
-	game.players[0].as_mut().unwrap().money = 500; // set the player to have less money
-    
-	// player2 will start as the small blind
-	let id2 = uuid::Uuid::new_v4();
+        game.players[0].as_mut().unwrap().money = 500; // set the player to have less money
+
+        // player2 will start as the small blind
+        let id2 = uuid::Uuid::new_v4();
         let name2 = "Human1".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
         game.add_user(settings2);
-	// flatten to get all the Some() players
-	let some_players = game.players.iter().flatten().count();
+        // flatten to get all the Some() players
+        let some_players = game.players.iter().flatten().count();
         assert_eq!(some_players, 2);
         assert!(game.players[0].as_ref().unwrap().human_controlled);
-	
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
 
+        let game = std::thread::scope(|scope| {
+            let handler = scope.spawn(move || {
+                game.play_one_hand();
+                game // return the game back
+            });
 
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	let handler = thread::spawn( move || {
-	    game.play_one_hand();
-	    game // return the game back
-	});
-	
-	// set the action that player2 bets
-	incoming_actions.lock().unwrap().insert(id2, PlayerAction::Bet(500));
-	// player1 calls
-	incoming_actions.lock().unwrap().insert(id1, PlayerAction::Call);
-	
-	// get the game back from the thread
-	let game = handler.join().unwrap();
+            // set the action that player2 bets
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id2, PlayerAction::Bet(500));
+            // player1 calls
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id1, PlayerAction::Call);
 
-	// the small blind won
-	assert_eq!(game.players[0].as_ref().unwrap().money, 0);
-	assert_eq!(game.players[1].as_ref().unwrap().money, 1500);	
+            // get the game back from the thread
+            handler.join().unwrap()
+        });
+
+        // the small blind won
+        assert_eq!(game.players[0].as_ref().unwrap().money, 0);
+        assert_eq!(game.players[1].as_ref().unwrap().money, 1500);
     }
 
     /// the small blind bets and the big blind calls
@@ -1692,167 +1749,231 @@ mod tests {
     /// and the big blind wins only the amount it puts in (500)
     #[test]
     fn small_stack_call_all_in() {
-	let mut deck = RiggedDeck::new();
+        let mut deck = RiggedDeck::new();
 
-	// we want the button/big blind to win for testing purposes
-	deck.push(Card{rank: Rank::Ten, suit: Suit::Club});
-	deck.push(Card{rank: Rank::Ten, suit: Suit::Heart});
+        // we want the button/big blind to win for testing purposes
+        deck.push(Card {
+            rank: Rank::Ten,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::Ten,
+            suit: Suit::Heart,
+        });
 
-	// now the small blind's losing hole cards	
-	deck.push(Card{rank: Rank::Two, suit: Suit::Club});
-	deck.push(Card{rank: Rank::Three, suit: Suit::Club});	
-	
-	// now the full run out
-	deck.push(Card{rank: Rank::Ten, suit: Suit::Diamond});
-	deck.push(Card{rank: Rank::Ten, suit: Suit::Spade});	
-	deck.push(Card{rank: Rank::King, suit: Suit::Club});
-	deck.push(Card{rank: Rank::King, suit: Suit::Heart});	
-	deck.push(Card{rank: Rank::Queen, suit: Suit::Club});
+        // now the small blind's losing hole cards
+        deck.push(Card {
+            rank: Rank::Two,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::Three,
+            suit: Suit::Club,
+        });
+
+        // now the full run out
+        deck.push(Card {
+            rank: Rank::Ten,
+            suit: Suit::Diamond,
+        });
+        deck.push(Card {
+            rank: Rank::Ten,
+            suit: Suit::Spade,
+        });
+        deck.push(Card {
+            rank: Rank::King,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::King,
+            suit: Suit::Heart,
+        });
+        deck.push(Card {
+            rank: Rank::Queen,
+            suit: Suit::Club,
+        });
 
         let mut game = Game::default();
-	game.deck = Box::new(deck);
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	game.incoming_actions = Some(&incoming_actions);
-	game.incoming_meta_actions = Some(&incoming_meta_actions);
-	
-	// player1 will start as the button/big
-	let id1 = uuid::Uuid::new_v4();
+        game.deck = Box::new(deck);
+        let incoming_actions = Mutex::new(HashMap::<Uuid, PlayerAction>::new());
+        let incoming_meta_actions = Mutex::new(VecDeque::<MetaAction>::new());
+        game.incoming_actions = Some(&incoming_actions);
+        game.incoming_meta_actions = Some(&incoming_meta_actions);
+
+        // player1 will start as the button/big
+        let id1 = uuid::Uuid::new_v4();
         let name1 = "Big".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
         game.add_user(settings1);
 
-	game.players[0].as_mut().unwrap().money = 500; // set the player to have less money
-    
-	// player2 will start as the small blind
-	let id2 = uuid::Uuid::new_v4();
+        game.players[0].as_mut().unwrap().money = 500; // set the player to have less money
+
+        // player2 will start as the small blind
+        let id2 = uuid::Uuid::new_v4();
         let name2 = "Small".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
         game.add_user(settings2);
-	// flatten to get all the Some() players
-	let some_players = game.players.iter().flatten().count();
+        // flatten to get all the Some() players
+        let some_players = game.players.iter().flatten().count();
         assert_eq!(some_players, 2);
         assert!(game.players[0].as_ref().unwrap().human_controlled);
-	
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
 
+        let game = std::thread::scope(|scope| {
+            let handler = scope.spawn(move || {
+                game.play_one_hand();
+                game // return the game back
+            });
 
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	let handler = thread::spawn( move || {
-	    game.play_one_hand();
-	    game // return the game back
-	});
-	
-	// set the action that player2 bets a bunch
-	incoming_actions.lock().unwrap().insert(id2, PlayerAction::Bet(1000));
-	// player1 calls
-	incoming_actions.lock().unwrap().insert(id1, PlayerAction::Call);
-	
-	// get the game back from the thread
-	let game = handler.join().unwrap();
+            // set the action that player2 bets a bunch
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id2, PlayerAction::Bet(1000));
+            // player1 calls
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id1, PlayerAction::Call);
 
-	// the big blind caller won, but only doubles its money
-	assert_eq!(game.players[0].as_ref().unwrap().money, 1000);
+            // get the game back from the thread
+            handler.join().unwrap()
+        });
 
-	// the small blind only loses half
-	assert_eq!(game.players[1].as_ref().unwrap().money, 500);	
+        // the big blind caller won, but only doubles its money
+        assert_eq!(game.players[0].as_ref().unwrap().money, 1000);
+
+        // the small blind only loses half
+        assert_eq!(game.players[1].as_ref().unwrap().money, 500);
     }
-    
+
     /// if a player goes all-in, then can only win as much as is called up to that amount,
     /// even if other players keep playing and betting during this hand
     /// In this test, the side pot is won by the short stack, then the remaining is won
     /// by another player
     #[test]
     fn outright_side_pot() {
-	let mut deck = RiggedDeck::new();
+        let mut deck = RiggedDeck::new();
 
-	// we want the button to win his side pot
-	deck.push(Card{rank: Rank::Ace, suit: Suit::Club});
-	deck.push(Card{rank: Rank::Ace, suit: Suit::Diamond});	
+        // we want the button to win his side pot
+        deck.push(Card {
+            rank: Rank::Ace,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::Ace,
+            suit: Suit::Diamond,
+        });
 
-	// the small blind will win the main pot against the big blind
-	deck.push(Card{rank: Rank::Ten, suit: Suit::Club});
-	deck.push(Card{rank: Rank::Ten, suit: Suit::Heart});
+        // the small blind will win the main pot against the big blind
+        deck.push(Card {
+            rank: Rank::Ten,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::Ten,
+            suit: Suit::Heart,
+        });
 
-	// the big blind loses
-	deck.push(Card{rank: Rank::Two, suit: Suit::Club});
-	deck.push(Card{rank: Rank::Four, suit: Suit::Heart});
-	
-	// now the full run out
-	deck.push(Card{rank: Rank::Three, suit: Suit::Diamond});
-	deck.push(Card{rank: Rank::Eight, suit: Suit::Spade});	
-	deck.push(Card{rank: Rank::Nine, suit: Suit::Club});
-	deck.push(Card{rank: Rank::King, suit: Suit::Heart});	
-	deck.push(Card{rank: Rank::King, suit: Suit::Club});
+        // the big blind loses
+        deck.push(Card {
+            rank: Rank::Two,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::Four,
+            suit: Suit::Heart,
+        });
+
+        // now the full run out
+        deck.push(Card {
+            rank: Rank::Three,
+            suit: Suit::Diamond,
+        });
+        deck.push(Card {
+            rank: Rank::Eight,
+            suit: Suit::Spade,
+        });
+        deck.push(Card {
+            rank: Rank::Nine,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::King,
+            suit: Suit::Heart,
+        });
+        deck.push(Card {
+            rank: Rank::King,
+            suit: Suit::Club,
+        });
 
         let mut game = Game::default();
-	game.deck = Box::new(deck);
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	game.incoming_actions = Some(&incoming_actions);
-	game.incoming_meta_actions = Some(&incoming_meta_actions);
+        game.deck = Box::new(deck);
+        let incoming_actions = Mutex::new(HashMap::<Uuid, PlayerAction>::new());
+        let incoming_meta_actions = Mutex::new(VecDeque::<MetaAction>::new());
+        game.incoming_actions = Some(&incoming_actions);
+        game.incoming_meta_actions = Some(&incoming_meta_actions);
 
-	// player1 will start as the button
-	let id1 = uuid::Uuid::new_v4();
+        // player1 will start as the button
+        let id1 = uuid::Uuid::new_v4();
         let name1 = "Button".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
         game.add_user(settings1);
-	// set the button to have less money so there is a side pot	
-	game.players[0].as_mut().unwrap().money = 500; 
-	
-	// player2 will start as the small blind
-	let id2 = uuid::Uuid::new_v4();
+        // set the button to have less money so there is a side pot
+        game.players[0].as_mut().unwrap().money = 500;
+
+        // player2 will start as the small blind
+        let id2 = uuid::Uuid::new_v4();
         let name2 = "Small".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
         game.add_user(settings2);
 
-	// player3 will start as the big blind
-	let id3 = uuid::Uuid::new_v4();
+        // player3 will start as the big blind
+        let id3 = uuid::Uuid::new_v4();
         let name3 = "Big".to_string();
         let settings3 = PlayerConfig::new(id3, Some(name3), None);
         game.add_user(settings3);
-	
-	// flatten to get all the Some() players
-	let some_players = game.players.iter().flatten().count();
+
+        // flatten to get all the Some() players
+        let some_players = game.players.iter().flatten().count();
         assert_eq!(some_players, 3);
         assert!(game.players[0].as_ref().unwrap().human_controlled);
         assert!(game.players[1].as_ref().unwrap().human_controlled);
-        assert!(game.players[2].as_ref().unwrap().human_controlled);	
-	
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
+        assert!(game.players[2].as_ref().unwrap().human_controlled);
 
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	let handler = thread::spawn( move || {
-	    game.play_one_hand();
-	    game // return the game back
-	});
-	
-	// the button goes all in with the short stack
-	incoming_actions.lock().unwrap().insert(id1, PlayerAction::Bet(500));
-	// the small blind goes all in with a full stack
-	incoming_actions.lock().unwrap().insert(id2, PlayerAction::Bet(1000));	
-	// the big blind calls the full all-in
-	incoming_actions.lock().unwrap().insert(id3, PlayerAction::Call);
-	
-	// get the game back from the thread
-	let game = handler.join().unwrap();
+        let game = std::thread::scope(|scope| {
+            let handler = scope.spawn(move || {
+                game.play_one_hand();
+                game // return the game back
+            });
 
-	// the button won the side pot
-	assert_eq!(game.players[0].as_ref().unwrap().money, 1500);
+            // the button goes all in with the short stack
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id1, PlayerAction::Bet(500));
+            // the small blind goes all in with a full stack
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id2, PlayerAction::Bet(1000));
+            // the big blind calls the full all-in
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id3, PlayerAction::Call);
 
-	// the small blind won the remainder
-	assert_eq!(game.players[1].as_ref().unwrap().money, 1000);
-	
-	// the big blind lost everything
-	assert_eq!(game.players[2].as_ref().unwrap().money, 0);	
+            // get the game back from the thread
+            handler.join().unwrap()
+        });
+
+        // the button won the side pot
+        assert_eq!(game.players[0].as_ref().unwrap().money, 1500);
+
+        // the small blind won the remainder
+        assert_eq!(game.players[1].as_ref().unwrap().money, 1000);
+
+        // the big blind lost everything
+        assert_eq!(game.players[2].as_ref().unwrap().money, 0);
     }
 
     /// if a player goes all-in, then can only win as much as is called up to that amount,
@@ -1861,251 +1982,340 @@ mod tests {
     /// This other player beats the third player in the side pot
     #[test]
     fn tie_side_pot() {
-	let mut deck = RiggedDeck::new();
+        let mut deck = RiggedDeck::new();
 
-	// we want the button to win the main pot
-	deck.push(Card{rank: Rank::Ace, suit: Suit::Club});
-	deck.push(Card{rank: Rank::Ace, suit: Suit::Diamond});	
+        // we want the button to win the main pot
+        deck.push(Card {
+            rank: Rank::Ace,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::Ace,
+            suit: Suit::Diamond,
+        });
 
-	// the small blind will tie the main and win the side pot against the big blind
-	deck.push(Card{rank: Rank::Ace, suit: Suit::Club});
-	deck.push(Card{rank: Rank::Ace, suit: Suit::Heart});
+        // the small blind will tie the main and win the side pot against the big blind
+        deck.push(Card {
+            rank: Rank::Ace,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::Ace,
+            suit: Suit::Heart,
+        });
 
-	// the big blind loses
-	deck.push(Card{rank: Rank::Two, suit: Suit::Club});
-	deck.push(Card{rank: Rank::Four, suit: Suit::Heart});
-	
-	// now the full run out
-	deck.push(Card{rank: Rank::Three, suit: Suit::Diamond});
-	deck.push(Card{rank: Rank::Eight, suit: Suit::Spade});	
-	deck.push(Card{rank: Rank::Nine, suit: Suit::Club});
-	deck.push(Card{rank: Rank::King, suit: Suit::Heart});	
-	deck.push(Card{rank: Rank::King, suit: Suit::Club});
-	
+        // the big blind loses
+        deck.push(Card {
+            rank: Rank::Two,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::Four,
+            suit: Suit::Heart,
+        });
+
+        // now the full run out
+        deck.push(Card {
+            rank: Rank::Three,
+            suit: Suit::Diamond,
+        });
+        deck.push(Card {
+            rank: Rank::Eight,
+            suit: Suit::Spade,
+        });
+        deck.push(Card {
+            rank: Rank::Nine,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::King,
+            suit: Suit::Heart,
+        });
+        deck.push(Card {
+            rank: Rank::King,
+            suit: Suit::Club,
+        });
+
         let mut game = Game::default();
-	game.deck = Box::new(deck);
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	game.incoming_actions = Some(&incoming_actions);
-	game.incoming_meta_actions = Some(&incoming_meta_actions);
+        game.deck = Box::new(deck);
+        let incoming_actions = Mutex::new(HashMap::<Uuid, PlayerAction>::new());
+        let incoming_meta_actions = Mutex::new(VecDeque::<MetaAction>::new());
+        game.incoming_actions = Some(&incoming_actions);
+        game.incoming_meta_actions = Some(&incoming_meta_actions);
 
-	// player1 will start as the button
-	let id1 = uuid::Uuid::new_v4();
+        // player1 will start as the button
+        let id1 = uuid::Uuid::new_v4();
         let name1 = "Button".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
         game.add_user(settings1);
-	// set the button to have less money so there is a side pot	
-	game.players[0].as_mut().unwrap().money = 500; 
-	
-	// player2 will start as the small blind
-	let id2 = uuid::Uuid::new_v4();
+        // set the button to have less money so there is a side pot
+        game.players[0].as_mut().unwrap().money = 500;
+
+        // player2 will start as the small blind
+        let id2 = uuid::Uuid::new_v4();
         let name2 = "Small".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
         game.add_user(settings2);
 
-	// player3 will start as the big blind
-	let id3 = uuid::Uuid::new_v4();
+        // player3 will start as the big blind
+        let id3 = uuid::Uuid::new_v4();
         let name3 = "Big".to_string();
         let settings3 = PlayerConfig::new(id3, Some(name3), None);
         game.add_user(settings3);
-	
-	// flatten to get all the Some() players
-	let some_players = game.players.iter().flatten().count();
+
+        // flatten to get all the Some() players
+        let some_players = game.players.iter().flatten().count();
         assert_eq!(some_players, 3);
         assert!(game.players[0].as_ref().unwrap().human_controlled);
         assert!(game.players[1].as_ref().unwrap().human_controlled);
-        assert!(game.players[2].as_ref().unwrap().human_controlled);	
-	
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
+        assert!(game.players[2].as_ref().unwrap().human_controlled);
 
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	let handler = thread::spawn( move || {
-	    game.play_one_hand();
-	    game // return the game back
-	});
-	
-	// the button goes all in with the short stack
-	incoming_actions.lock().unwrap().insert(id1, PlayerAction::Bet(500));
-	// the small blind goes all in with a full stack
-	incoming_actions.lock().unwrap().insert(id2, PlayerAction::Bet(1000));	
-	// the big blind calls the full all-in
-	incoming_actions.lock().unwrap().insert(id3, PlayerAction::Call);
-	
-	// get the game back from the thread
-	let game = handler.join().unwrap();
+        let game = std::thread::scope(|scope| {
+            let handler = scope.spawn(move || {
+                game.play_one_hand();
+                game // return the game back
+            });
 
-	// the button won the side pot
-	assert_eq!(game.players[0].as_ref().unwrap().money, 750);
+            // the button goes all in with the short stack
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id1, PlayerAction::Bet(500));
+            // the small blind goes all in with a full stack
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id2, PlayerAction::Bet(1000));
+            // the big blind calls the full all-in
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id3, PlayerAction::Call);
 
-	// the small blind won the remainder
-	assert_eq!(game.players[1].as_ref().unwrap().money, 1750);
-	
-	// the big blind lost everything
-	assert_eq!(game.players[2].as_ref().unwrap().money, 0);	
+            // get the game back from the thread
+            handler.join().unwrap()
+        });
+
+        // the button won the side pot
+        assert_eq!(game.players[0].as_ref().unwrap().money, 750);
+
+        // the small blind won the remainder
+        assert_eq!(game.players[1].as_ref().unwrap().money, 1750);
+
+        // the big blind lost everything
+        assert_eq!(game.players[2].as_ref().unwrap().money, 0);
     }
 
     /// if a player goes all-in, then can only win as much as is called up to that amount,
     /// even if other players keep playing and betting during this hand
     /// In this test, the main pot is won by the small stack, then medium stack wins a separate
     /// side pot, and finally, the rest of the chips are won by a third player
-    
+
     #[test]
     fn multiple_side_pots() {
-	let mut deck = RiggedDeck::new();
+        let mut deck = RiggedDeck::new();
 
-	// we want the button to win the main pot
-	deck.push(Card{rank: Rank::Ace, suit: Suit::Club});
-	deck.push(Card{rank: Rank::Ace, suit: Suit::Diamond});	
+        // we want the button to win the main pot
+        deck.push(Card {
+            rank: Rank::Ace,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::Ace,
+            suit: Suit::Diamond,
+        });
 
-	// the small blind will win the remaining
-	deck.push(Card{rank: Rank::Six, suit: Suit::Club});
-	deck.push(Card{rank: Rank::Six  , suit: Suit::Heart});
+        // the small blind will win the remaining
+        deck.push(Card {
+            rank: Rank::Six,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::Six,
+            suit: Suit::Heart,
+        });
 
-	// the big blind loses
-	deck.push(Card{rank: Rank::Two, suit: Suit::Club});
-	deck.push(Card{rank: Rank::Four, suit: Suit::Heart});
+        // the big blind loses
+        deck.push(Card {
+            rank: Rank::Two,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::Four,
+            suit: Suit::Heart,
+        });
 
-	// UTG wins the second side pot
-	deck.push(Card{rank: Rank::Queen, suit: Suit::Club});
-	deck.push(Card{rank: Rank::Queen, suit: Suit::Heart});
-	
-	// now the full run out
-	deck.push(Card{rank: Rank::Three, suit: Suit::Diamond});
-	deck.push(Card{rank: Rank::Eight, suit: Suit::Spade});	
-	deck.push(Card{rank: Rank::Nine, suit: Suit::Club});
-	deck.push(Card{rank: Rank::King, suit: Suit::Heart});	
-	deck.push(Card{rank: Rank::King, suit: Suit::Club});
+        // UTG wins the second side pot
+        deck.push(Card {
+            rank: Rank::Queen,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::Queen,
+            suit: Suit::Heart,
+        });
+
+        // now the full run out
+        deck.push(Card {
+            rank: Rank::Three,
+            suit: Suit::Diamond,
+        });
+        deck.push(Card {
+            rank: Rank::Eight,
+            suit: Suit::Spade,
+        });
+        deck.push(Card {
+            rank: Rank::Nine,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::King,
+            suit: Suit::Heart,
+        });
+        deck.push(Card {
+            rank: Rank::King,
+            suit: Suit::Club,
+        });
 
         let mut game = Game::default();
-	game.deck = Box::new(deck);
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	game.incoming_actions = Some(&incoming_actions);
-	game.incoming_meta_actions = Some(&incoming_meta_actions);
-	
-	// player1 will start as the button
-	let id1 = uuid::Uuid::new_v4();
+        game.deck = Box::new(deck);
+        let incoming_actions = Mutex::new(HashMap::<Uuid, PlayerAction>::new());
+        let incoming_meta_actions = Mutex::new(VecDeque::<MetaAction>::new());
+        game.incoming_actions = Some(&incoming_actions);
+        game.incoming_meta_actions = Some(&incoming_meta_actions);
+
+        // player1 will start as the button
+        let id1 = uuid::Uuid::new_v4();
         let name1 = "Button".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
         game.add_user(settings1);
-	// set the button to have less money so there is a side pot	
-	game.players[0].as_mut().unwrap().money = 500; 
-	
-	// player2 will start as the small blind
-	let id2 = uuid::Uuid::new_v4();
+        // set the button to have less money so there is a side pot
+        game.players[0].as_mut().unwrap().money = 500;
+
+        // player2 will start as the small blind
+        let id2 = uuid::Uuid::new_v4();
         let name2 = "Small".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
         game.add_user(settings2);
 
-	// player3 will start as the big blind
-	let id3 = uuid::Uuid::new_v4();
+        // player3 will start as the big blind
+        let id3 = uuid::Uuid::new_v4();
         let name3 = "Big".to_string();
         let settings3 = PlayerConfig::new(id3, Some(name3), None);
         game.add_user(settings3);
 
-	// player4 will start as UTG
-	let id4 = uuid::Uuid::new_v4();
+        // player4 will start as UTG
+        let id4 = uuid::Uuid::new_v4();
         let name4 = "UTG".to_string();
         let settings4 = PlayerConfig::new(id4, Some(name4), None);
         game.add_user(settings4);
-	// set UTG to have medium money so there is a second side pot	
-	game.players[3].as_mut().unwrap().money = 750; 
-	
-	// flatten to get all the Some() players
-	let some_players = game.players.iter().flatten().count();
+        // set UTG to have medium money so there is a second side pot
+        game.players[3].as_mut().unwrap().money = 750;
+
+        // flatten to get all the Some() players
+        let some_players = game.players.iter().flatten().count();
         assert_eq!(some_players, 4);
         assert!(game.players[0].as_ref().unwrap().human_controlled);
         assert!(game.players[1].as_ref().unwrap().human_controlled);
         assert!(game.players[2].as_ref().unwrap().human_controlled);
-        assert!(game.players[3].as_ref().unwrap().human_controlled);			
+        assert!(game.players[3].as_ref().unwrap().human_controlled);
 
-	let handler = thread::spawn( move || {
-	    game.play_one_hand();
-	    game // return the game back
-	});
+        let game = std::thread::scope(|scope| {
+            let handler = scope.spawn(move || {
+                game.play_one_hand();
+                game // return the game back
+            });
 
-	// UTG goes all in with the medium stack
-	incoming_actions.lock().unwrap().insert(id4, PlayerAction::Bet(750));
-	// the button calls (and thus goes all in with the short stack)
-	incoming_actions.lock().unwrap().insert(id1, PlayerAction::Call);
-	// the small blind goes all in with a full stack
-	incoming_actions.lock().unwrap().insert(id2, PlayerAction::Bet(1000));	
-	// the big blind calls the full all-in
-	incoming_actions.lock().unwrap().insert(id3, PlayerAction::Call);
-	
-	// get the game back from the thread
-	let game = handler.join().unwrap();
+            // UTG goes all in with the medium stack
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id4, PlayerAction::Bet(750));
+            // the button calls (and thus goes all in with the short stack)
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id1, PlayerAction::Call);
+            // the small blind goes all in with a full stack
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id2, PlayerAction::Bet(1000));
+            // the big blind calls the full all-in
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id3, PlayerAction::Call);
 
-	// the button won the side pot
-	assert_eq!(game.players[0].as_ref().unwrap().money, 2000);
+            // get the game back from the thread
+            handler.join().unwrap()
+        });
 
-	// the small blind won the remainder
-	assert_eq!(game.players[1].as_ref().unwrap().money, 500);
-	
-	// the big blind lost everything
-	assert_eq!(game.players[2].as_ref().unwrap().money, 0);
-	
-	// UTG won the second side pot
-	assert_eq!(game.players[3].as_ref().unwrap().money, 750);	
+        // the button won the side pot
+        assert_eq!(game.players[0].as_ref().unwrap().money, 2000);
+
+        // the small blind won the remainder
+        assert_eq!(game.players[1].as_ref().unwrap().money, 500);
+
+        // the big blind lost everything
+        assert_eq!(game.players[2].as_ref().unwrap().money, 0);
+
+        // UTG won the second side pot
+        assert_eq!(game.players[3].as_ref().unwrap().money, 750);
     }
 
     /// can we pass a hand limit of 2 and the game comes to an end
     #[test]
     fn hand_limit() {
         let mut game = Game::default();
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	game.incoming_actions = Some(&incoming_actions);
-	game.incoming_meta_actions = Some(&incoming_meta_actions);
+        let incoming_actions = Mutex::new(HashMap::<Uuid, PlayerAction>::new());
+        let incoming_meta_actions = Mutex::new(VecDeque::<MetaAction>::new());
+        game.incoming_actions = Some(&incoming_actions);
+        game.incoming_meta_actions = Some(&incoming_meta_actions);
 
-	// player1 will start as the button
-	let id1 = uuid::Uuid::new_v4();
+        // player1 will start as the button
+        let id1 = uuid::Uuid::new_v4();
         let name1 = "Human1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
         game.add_user(settings1);
 
-	// player2 will start as the small blind
-	let id2 = uuid::Uuid::new_v4();
+        // player2 will start as the small blind
+        let id2 = uuid::Uuid::new_v4();
         let name2 = "Human1".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
         game.add_user(settings2);
-	// flatten to get all the Some() players
-	let some_players = game.players.iter().flatten().count();
+        // flatten to get all the Some() players
+        let some_players = game.players.iter().flatten().count();
         assert_eq!(some_players, 2);
         assert!(game.players[0].as_ref().unwrap().human_controlled);
-	
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
 
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	let handler = thread::spawn( move || {
-	    game.play(Some(2));
-	    game // return the game back
-	});
-	
-	// set the action that player2 folds
-	incoming_actions.lock().unwrap().insert(id2, PlayerAction::Fold);
+        let game = std::thread::scope(|scope| {
+            let handler = scope.spawn(move || {
+                game.play(Some(2));
+                game // return the game back
+            });
 
-	// then player1 folds next hand
-	incoming_actions.lock().unwrap().insert(id1, PlayerAction::Fold);	
+            // set the action that player2 folds
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id2, PlayerAction::Fold);
 
-	// get the game back from the thread
-	let game = handler.join().unwrap();
-	
-	// check that the money balances out
-	assert_eq!(game.players[0].as_ref().unwrap().money, 1000);
-	assert_eq!(game.players[1].as_ref().unwrap().money, 1000);
+            // then player1 folds next hand
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id1, PlayerAction::Fold);
+
+            // get the game back from the thread
+            handler.join().unwrap()
+        });
+
+        // check that the money balances out
+        assert_eq!(game.players[0].as_ref().unwrap().money, 1000);
+        assert_eq!(game.players[1].as_ref().unwrap().money, 1000);
     }
-    
+
     /// check that the button moves around properly
     /// we play 4 hands with 3 players with everyone folding whenever it gets to them,
     /// Note: we sleep several seconds in the test to let the game finish its hand in its thread,
@@ -2114,86 +2324,105 @@ mod tests {
     /// durations
     #[test]
     fn button_movement() {
-        let mut game = Game::default();	
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	game.incoming_actions = Some(&incoming_actions);
-	game.incoming_meta_actions = Some(&incoming_meta_actions);
+        let mut game = Game::default();
+        let incoming_actions = Mutex::new(HashMap::<Uuid, PlayerAction>::new());
+        let incoming_meta_actions = Mutex::new(VecDeque::<MetaAction>::new());
+        game.incoming_actions = Some(&incoming_actions);
+        game.incoming_meta_actions = Some(&incoming_meta_actions);
 
-	let id1 = uuid::Uuid::new_v4();
+        let id1 = uuid::Uuid::new_v4();
         let name1 = "Human1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
         game.add_user(settings1);
 
-	let id2 = uuid::Uuid::new_v4();
+        let id2 = uuid::Uuid::new_v4();
         let name2 = "Human2".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
         game.add_user(settings2);
 
-	let id3 = uuid::Uuid::new_v4();
+        let id3 = uuid::Uuid::new_v4();
         let name3 = "Human3".to_string();
         let settings3 = PlayerConfig::new(id3, Some(name3), None);
         game.add_user(settings3);
 
-	// flatten to get all the Some() players
-	let some_players = game.players.iter().flatten().count();
+        // flatten to get all the Some() players
+        let some_players = game.players.iter().flatten().count();
         assert_eq!(some_players, 3);
         assert!(game.players[0].as_ref().unwrap().human_controlled);
-	
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
 
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	let num_hands = 4;
-	let handler = thread::spawn( move || {
-	    game.play(Some(num_hands));
-	    game // return the game back
-	});
+        let num_hands = 4;
+        let game = std::thread::scope(|scope| {
+            let handler = scope.spawn(move || {
+                game.play_one_hand();
+                game // return the game back
+            });
 
-	// id3 should not have to act as the big blind
-	println!("\n\nsetting 1!");
-	incoming_actions.lock().unwrap().insert(id1, PlayerAction::Fold);	
-	incoming_actions.lock().unwrap().insert(id2, PlayerAction::Fold);
-	//incoming_actions.lock().unwrap().insert(id4, PlayerAction::Fold);	
+            // id3 should not have to act as the big blind
+            println!("\n\nsetting 1!");
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id1, PlayerAction::Fold);
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id2, PlayerAction::Fold);
+            //incoming_actions.lock().unwrap().insert(id4, PlayerAction::Fold);
 
-	// wait for next hand
-        let wait_duration = time::Duration::from_secs(8);
-	std::thread::sleep(wait_duration);
+            // wait for next hand
+            let wait_duration = time::Duration::from_secs(8);
+            thread::sleep(wait_duration);
 
-	println!("\n\nsetting 2!");	
-	// id1 should not have to act as the big blind
-	incoming_actions.lock().unwrap().insert(id2, PlayerAction::Fold);
-	incoming_actions.lock().unwrap().insert(id3, PlayerAction::Fold);		
+            println!("\n\nsetting 2!");
+            // id1 should not have to act as the big blind
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id2, PlayerAction::Fold);
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id3, PlayerAction::Fold);
 
-	// wait for next hand
-	std::thread::sleep(wait_duration);
+            // wait for next hand
+            thread::sleep(wait_duration);
 
-	println!("\n\nsetting 3!");		
-	// id2 should not have to act as the big blind
-	incoming_actions.lock().unwrap().insert(id1, PlayerAction::Fold);
-	incoming_actions.lock().unwrap().insert(id3, PlayerAction::Fold);		
+            println!("\n\nsetting 3!");
+            // id2 should not have to act as the big blind
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id1, PlayerAction::Fold);
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id3, PlayerAction::Fold);
 
-	// wait for next hand
-	std::thread::sleep(wait_duration);	
+            // wait for next hand
+            thread::sleep(wait_duration);
 
-	// We should be back to the beginning with the button,
-	// so id1 should be the button, and id3 should be the big blind
-	// id3 should not have to act as the big blind
-	println!("\n\nsetting 4!");				
-	incoming_actions.lock().unwrap().insert(id1, PlayerAction::Fold);
-	incoming_actions.lock().unwrap().insert(id2, PlayerAction::Fold);
-	//incoming_actions.lock().unwrap().insert(id4, PlayerAction::Fold);			
-	
-	let game = handler.join().unwrap();
-	
-	// Everyone lost their small blind and won someone else's small blind
-	// then in the last hand, id3 won the small blind from id2
-	assert_eq!(game.players[0].as_ref().unwrap().money, 1000);
-	assert_eq!(game.players[1].as_ref().unwrap().money, 996);
-	assert_eq!(game.players[2].as_ref().unwrap().money, 1004);
+            // We should be back to the beginning with the button,
+            // so id1 should be the button, and id3 should be the big blind
+            // id3 should not have to act as the big blind
+            println!("\n\nsetting 4!");
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id1, PlayerAction::Fold);
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id2, PlayerAction::Fold);
+            //incoming_actions.lock().unwrap().insert(id4, PlayerAction::Fold);
+
+            handler.join().unwrap()
+        });
+
+        // Everyone lost their small blind and won someone else's small blind
+        // then in the last hand, id3 won the small blind from id2
+        assert_eq!(game.players[0].as_ref().unwrap().money, 1000);
+        assert_eq!(game.players[1].as_ref().unwrap().money, 996);
+        assert_eq!(game.players[2].as_ref().unwrap().money, 1004);
     }
 
     /// the small blind calls, the big blind checks to the flop
@@ -2201,76 +2430,83 @@ mod tests {
     /// a player joins during the hand, and it works fine
     #[test]
     fn mid_hand_join() {
-        let mut game = Game::default();		
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	game.incoming_actions = Some(&incoming_actions);
-	game.incoming_meta_actions = Some(&incoming_meta_actions);
+        let mut game = Game::default();
+        let incoming_actions = Mutex::new(HashMap::<Uuid, PlayerAction>::new());
+        let incoming_meta_actions = Mutex::new(VecDeque::<MetaAction>::new());
+        game.incoming_actions = Some(&incoming_actions);
+        game.incoming_meta_actions = Some(&incoming_meta_actions);
 
-	// player1 will start as the button
-	let id1 = uuid::Uuid::new_v4();
+        // player1 will start as the button
+        let id1 = uuid::Uuid::new_v4();
         let name1 = "Human1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
         game.add_user(settings1);
 
-	// player2 will start as the small blind
-	let id2 = uuid::Uuid::new_v4();
+        // player2 will start as the small blind
+        let id2 = uuid::Uuid::new_v4();
         let name2 = "Human2".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
         game.add_user(settings2);
-	// flatten to get all the Some() players
-	let some_players = game.players.iter().flatten().count();
+        // flatten to get all the Some() players
+        let some_players = game.players.iter().flatten().count();
         assert_eq!(some_players, 2);
         assert!(game.players[0].as_ref().unwrap().human_controlled);
-	
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
 
+        let game = std::thread::scope(|scope| {
+            let handler = scope.spawn(move || {
+                game.play_one_hand();
+                game // return the game back
+            });
 
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	let handler = thread::spawn( move || {
-	    game.play_one_hand();
-	    game // return the game back
-	});
-	
-	// set the action that player2 calls
-	incoming_actions.lock().unwrap().insert(id2, PlayerAction::Call);
-	// player1 checks
-	incoming_actions.lock().unwrap().insert(id1, PlayerAction::Check);
+            // set the action that player2 calls
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id2, PlayerAction::Call);
+            // player1 checks
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id1, PlayerAction::Check);
 
+            // a new player joins the game
+            let id3 = uuid::Uuid::new_v4();
+            let name3 = "Human3".to_string();
+            let settings3 = PlayerConfig::new(id3, Some(name3), None);
+            incoming_meta_actions
+                .lock()
+                .unwrap()
+                .push_back(MetaAction::Join(settings3));
 
-	// a new player joins the game
-	let id3 = uuid::Uuid::new_v4();
-        let name3 = "Human3".to_string();
-        let settings3 = PlayerConfig::new(id3, Some(name3), None);
-	incoming_meta_actions.lock().unwrap().push_back(MetaAction::Join(settings3));
-	
-	// wait for the flop
-        let wait_duration = time::Duration::from_secs(8);
-	std::thread::sleep(wait_duration);
+            // wait for the flop
+            let wait_duration = time::Duration::from_secs(8);
+            thread::sleep(wait_duration);
 
-	// player2 bets on the flop
-	println!("now sending the flop actions");	
-	incoming_actions.lock().unwrap().insert(id2, PlayerAction::Bet(10));
-	// player1 folds
-	incoming_actions.lock().unwrap().insert(id1, PlayerAction::Fold);
-	
-	// get the game back from the thread
-	let game = handler.join().unwrap();
+            // player2 bets on the flop
+            println!("now sending the flop actions");
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id2, PlayerAction::Bet(10));
+            // player1 folds
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id1, PlayerAction::Fold);
 
-	// there is another player now
-	let some_players = game.players.iter().flatten().count();
+            // get the game back from the thread
+            handler.join().unwrap()
+        });
+
+        // there is another player now
+        let some_players = game.players.iter().flatten().count();
         assert_eq!(some_players, 3);
-	
-	// check that the money changed hands
-	assert_eq!(game.players[0].as_ref().unwrap().money, 992);
-	assert_eq!(game.players[1].as_ref().unwrap().money, 1008);
-	assert_eq!(game.players[2].as_ref().unwrap().money, 1000);
-	assert!(!game.players[2].as_ref().unwrap().is_active);			
-	
+
+        // check that the money changed hands
+        assert_eq!(game.players[0].as_ref().unwrap().money, 992);
+        assert_eq!(game.players[1].as_ref().unwrap().money, 1008);
+        assert_eq!(game.players[2].as_ref().unwrap().money, 1000);
+        assert!(!game.players[2].as_ref().unwrap().is_active);
     }
 
     /// player1 has the best hand, but chooses to sit out mid hand,
@@ -2278,90 +2514,125 @@ mod tests {
     /// It doesn't actually matter what the hands are, since it doesn't go to showdown
     #[test]
     fn sit_out() {
-	let mut deck = RiggedDeck::new();
+        let mut deck = RiggedDeck::new();
 
-	// we want the button to have the best hand
-	deck.push(Card{rank: Rank::Ace, suit: Suit::Club});
-	deck.push(Card{rank: Rank::Ace, suit: Suit::Diamond});	
+        // we want the button to have the best hand
+        deck.push(Card {
+            rank: Rank::Ace,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::Ace,
+            suit: Suit::Diamond,
+        });
 
-	// the small blind player2 wins regardless
-	deck.push(Card{rank: Rank::Six, suit: Suit::Club});
-	deck.push(Card{rank: Rank::Five, suit: Suit::Heart});
+        // the small blind player2 wins regardless
+        deck.push(Card {
+            rank: Rank::Six,
+            suit: Suit::Club,
+        });
+        deck.push(Card {
+            rank: Rank::Five,
+            suit: Suit::Heart,
+        });
 
-	// the flop
-	deck.push(Card{rank: Rank::Ace, suit: Suit::Heart});
-	deck.push(Card{rank: Rank::Ace, suit: Suit::Spade});
-	deck.push(Card{rank: Rank::King, suit: Suit::Heart});
-	
+        // the flop
+        deck.push(Card {
+            rank: Rank::Ace,
+            suit: Suit::Heart,
+        });
+        deck.push(Card {
+            rank: Rank::Ace,
+            suit: Suit::Spade,
+        });
+        deck.push(Card {
+            rank: Rank::King,
+            suit: Suit::Heart,
+        });
+
         let mut game = Game::default();
-	game.deck = Box::new(deck);			
-	let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));	
-	let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
-	let cloned_actions = incoming_actions.clone();	    
-	let cloned_meta_actions = incoming_meta_actions.clone();
-	game.incoming_actions = Some(&incoming_actions);
-	game.incoming_meta_actions = Some(&incoming_meta_actions);
-	
-	// player1 will start as the button
-	let id1 = uuid::Uuid::new_v4();
+        game.deck = Box::new(deck);
+        let incoming_actions = Mutex::new(HashMap::<Uuid, PlayerAction>::new());
+        let incoming_meta_actions = Mutex::new(VecDeque::<MetaAction>::new());
+        game.incoming_actions = Some(&incoming_actions);
+        game.incoming_meta_actions = Some(&incoming_meta_actions);
+
+        // player1 will start as the button
+        let id1 = uuid::Uuid::new_v4();
         let name1 = "Human1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
         game.add_user(settings1);
 
-	// player2 will start as the small blind
-	let id2 = uuid::Uuid::new_v4();
+        // player2 will start as the small blind
+        let id2 = uuid::Uuid::new_v4();
         let name2 = "Human2".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
         game.add_user(settings2);
-	
-	// flatten to get all the Some() players
-	let some_players = game.players.iter().flatten().count();
+
+        // flatten to get all the Some() players
+        let some_players = game.players.iter().flatten().count();
         assert_eq!(some_players, 2);
         assert!(game.players[0].as_ref().unwrap().human_controlled);
 
-	// both players not sitting out to start
-	let not_sitting_out = game.players.iter().flatten().filter(|x| !x.is_sitting_out).count();
-	assert_eq!(not_sitting_out, 2);
+        // both players not sitting out to start
+        let not_sitting_out = game
+            .players
+            .iter()
+            .flatten()
+            .filter(|x| !x.is_sitting_out)
+            .count();
+        assert_eq!(not_sitting_out, 2);
 
-	
-	let handler = thread::spawn( move || {
-	    game.play_one_hand();
-	    game // return the game back
-	});
-	
-	// set the action that player2 calls
-	incoming_actions.lock().unwrap().insert(id2, PlayerAction::Call);
-	// player1 checks
-	incoming_actions.lock().unwrap().insert(id1, PlayerAction::Check);
-	
-	// wait for the flop
-        let wait_duration = time::Duration::from_secs(8);
-	std::thread::sleep(wait_duration);
+        let game = std::thread::scope(|scope| {
+            let handler = scope.spawn(move || {
+                game.play_one_hand();
+                game // return the game back
+            });
 
-	// player2 bets on the flop
-	println!("now sending the flop actions");	
-	incoming_actions.lock().unwrap().insert(id2, PlayerAction::Bet(10));
+            // set the action that player2 calls
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id2, PlayerAction::Call);
+            // player1 checks
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id1, PlayerAction::Check);
 
+            // wait for the flop
+            let wait_duration = time::Duration::from_secs(8);
+            thread::sleep(wait_duration);
 
-	// player1 sits out, which folds and moves on
-	incoming_meta_actions.lock().unwrap().push_back(MetaAction::SitOut(id1));
-	
-	// get the game back from the thread
-	let game = handler.join().unwrap();
+            // player2 bets on the flop
+            println!("now sending the flop actions");
+            incoming_actions
+                .lock()
+                .unwrap()
+                .insert(id2, PlayerAction::Bet(10));
 
-	// one player sitting out
-	let not_sitting_out = game.players.iter().flatten().filter(|x| !x.is_sitting_out).count();
-	assert_eq!(not_sitting_out, 1);
-	    
-	// check that the money changed hands
-	assert_eq!(game.players[0].as_ref().unwrap().money, 992);
-	assert_eq!(game.players[1].as_ref().unwrap().money, 1008);
-	assert!(!game.players[0].as_ref().unwrap().is_active);		
-	
-	
+            // player1 sits out, which folds and moves on
+            incoming_meta_actions
+                .lock()
+                .unwrap()
+                .push_back(MetaAction::SitOut(id1));
+
+            // get the game back from the thread
+            handler.join().unwrap()
+        });
+
+        // one player sitting out
+        let not_sitting_out = game
+            .players
+            .iter()
+            .flatten()
+            .filter(|x| !x.is_sitting_out)
+            .count();
+        assert_eq!(not_sitting_out, 1);
+
+        // check that the money changed hands
+        assert_eq!(game.players[0].as_ref().unwrap().money, 992);
+        assert_eq!(game.players[1].as_ref().unwrap().money, 1008);
+        assert!(!game.players[0].as_ref().unwrap().is_active);
     }
-    
 }
-
-
-

--- a/src/logic/game.rs
+++ b/src/logic/game.rs
@@ -990,7 +990,6 @@ pub struct Game<'a> {
     small_blind: u32,
     big_blind: u32,
     buy_in: u32,
-    is_private: bool, // will it show up in the list of games
     password: Option<String>,
 }
 
@@ -1010,7 +1009,6 @@ impl<'a> Default for Game<'a> {
             small_blind: 4,
             big_blind: 8,
             buy_in: 1000,
-            is_private: true,
             password: None,
         }
     }
@@ -1029,7 +1027,6 @@ impl<'a> Game<'a> {
         small_blind: u32,
         big_blind: u32,
         buy_in: u32,
-        is_private: bool, // will it show up in the list of games
         password: Option<String>,
     ) -> Self {
         let deck = if deck_opt.is_some() {
@@ -1050,7 +1047,6 @@ impl<'a> Game<'a> {
             small_blind,
             big_blind,
             buy_in,
-            is_private,
             password,
         }
     }
@@ -1086,6 +1082,7 @@ impl<'a> Game<'a> {
                 let message = object! {
                     msg_type: "joined_game".to_owned(),
                     index: i,
+		    table_name: self.name.clone(),
                 };
                 PlayerConfig::send_specific_message(
                     &message.dump(),

--- a/src/logic/mod.rs
+++ b/src/logic/mod.rs
@@ -3,5 +3,5 @@ pub mod game;
 pub mod player;
 
 pub use game::Game;
-pub use player::PlayerConfig;
 pub use player::PlayerAction;
+pub use player::PlayerConfig;

--- a/src/logic/player.rs
+++ b/src/logic/player.rs
@@ -1,8 +1,8 @@
 use super::card::Card;
 use crate::messages::WsMessage;
 use actix::prelude::Recipient;
-use uuid::Uuid;
 use std::collections::HashMap;
+use uuid::Uuid;
 
 #[derive(Debug, Copy, Clone)]
 pub enum PlayerAction {
@@ -33,7 +33,7 @@ impl PlayerConfig {
 
     /// given a message, send it to all players in the HashMap that have a Recipient address    
     pub fn send_group_message(message: &str, ids_to_configs: &HashMap<Uuid, PlayerConfig>) {
-	for player_config in ids_to_configs.values() {
+        for player_config in ids_to_configs.values() {
             if let Some(addr) = &player_config.player_addr {
                 addr.do_send(WsMessage(message.to_owned()));
             }
@@ -41,31 +41,39 @@ impl PlayerConfig {
     }
 
     /// send a given message to one player
-    pub fn send_specific_message(message: &str, id: Uuid, ids_to_configs: &HashMap<Uuid, PlayerConfig>) {
-	if let Some(player_config) = ids_to_configs.get(&id) {
+    pub fn send_specific_message(
+        message: &str,
+        id: Uuid,
+        ids_to_configs: &HashMap<Uuid, PlayerConfig>,
+    ) {
+        if let Some(player_config) = ids_to_configs.get(&id) {
             if let Some(addr) = &player_config.player_addr {
-		addr.do_send(WsMessage(message.to_owned()));
-	    }
-	}
+                addr.do_send(WsMessage(message.to_owned()));
+            }
+        }
     }
 
     /// find a player with the given id, and set their name to be the given name
     pub fn set_player_name(id: Uuid, name: &str, ids_to_configs: &mut HashMap<Uuid, PlayerConfig>) {
-	if let Some(player_config) = ids_to_configs.get_mut(&id) {
+        if let Some(player_config) = ids_to_configs.get_mut(&id) {
             player_config.name = Some(name.to_string());
-            player_config.player_addr.as_ref().unwrap()
-		.do_send(
-		    WsMessage(format!("You are changing your name to {:?}", name))
-		);	    	    
-	}
-    }    
+            player_config
+                .player_addr
+                .as_ref()
+                .unwrap()
+                .do_send(WsMessage(format!(
+                    "You are changing your name to {:?}",
+                    name
+                )));
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct Player {
     pub id: Uuid,
     pub human_controlled: bool, // do we need user input or let the computer control it
-    pub money: u32,    
+    pub money: u32,
     pub is_active: bool,      // is still playing the current hand
     pub is_sitting_out: bool, // if sitting out, then they are not active for any future hand
     pub hole_cards: Vec<Card>,
@@ -75,11 +83,11 @@ impl Player {
     pub fn new(id: Uuid, human_controlled: bool, money: u32) -> Self {
         Player {
             id,
-            human_controlled,	    	    
-            money,	    
+            human_controlled,
+            money,
             is_active: false, // a branch new player is not active in a hand
             is_sitting_out: false,
-            hole_cards: Vec::<Card>::with_capacity(2),	    
+            hole_cards: Vec::<Card>::with_capacity(2),
         }
     }
 

--- a/src/logic/player.rs
+++ b/src/logic/player.rs
@@ -84,9 +84,9 @@ impl Player {
     }
 
     /// create a new bot from scratch
-    pub fn new_bot() -> Self {
+    pub fn new_bot(money: u32) -> Self {
         let bot_id = Uuid::new_v4(); // can just gen a new arbitrary id for the bot
-        Self::new(bot_id, false, 1000)
+        Self::new(bot_id, false, money)
     }
 
     pub fn pay(&mut self, payment: u32) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,9 +66,9 @@ async fn main() -> std::io::Result<()> {
             .service(Files::new("/static", "./static"))
             .wrap(Logger::default())
     })
-	.workers(2)
-	.bind(("127.0.0.1", 8080))?
-    //	.bind(("192.168.1.91", 8080))?	
-	.run()
-	.await
+    .workers(2)
+    .bind(("127.0.0.1", 8080))?
+    //	.bind(("192.168.1.91", 8080))?
+    .run()
+    .await
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,8 +1,8 @@
 use crate::logic::{player::PlayerAction, PlayerConfig};
 use actix::prelude::{Message, Recipient};
-use uuid::Uuid;
-use std::fmt;
 use serde_json::Value;
+use std::fmt;
+use uuid::Uuid;
 
 /// Game server sends this messages to session
 
@@ -12,10 +12,10 @@ use serde_json::Value;
 pub enum MetaAction {
     Join(PlayerConfig),
     Leave(Uuid),
-    ImBack(Uuid),    
+    ImBack(Uuid),
     SitOut(Uuid),
     PlayerName(Uuid, String),
-    Chat(Uuid, String), 
+    Chat(Uuid, String),
 }
 
 #[derive(Message)]
@@ -70,48 +70,49 @@ pub struct PlayerName {
     pub name: String,
 }
 
-
 pub enum CreateGameError {
     NameNotSet,
     MissingField,
     InvalidFieldValue(String), // contains the invalid field
-    AlreadyAtTable(String), // contains the table name
+    AlreadyAtTable(String),    // contains the table name
 }
 
 impl fmt::Display for CreateGameError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-	match self {
-	    CreateGameError::NameNotSet => {
-		write!(f, "Unable to create a game since you have not set your name")
-	    },
-	    CreateGameError::MissingField => {
-		write!(f, "Unable to create a game since missing field(s)")
-		/*
-		write!(f, "Unable to create a game since command is missing fields:")?;
-		for field in missing_fields {
-		    write!(f, format!("{:?}", field))?;
-		}
-		Ok(())
-		 */
-	    },
-	    CreateGameError::AlreadyAtTable(table_name) => {
-		write!(
-		    f,
-		    "Unable to create a game since already at a table: {}",
-		    table_name
-		)
-	    },
-	    CreateGameError::InvalidFieldValue(invalid_field) => {
-		write!(
-		    f,
-		    "Unable to create a game since invalid field value: {}",
-		    invalid_field
-		)
-	    }
-	}
+        match self {
+            CreateGameError::NameNotSet => {
+                write!(
+                    f,
+                    "Unable to create a game since you have not set your name"
+                )
+            }
+            CreateGameError::MissingField => {
+                write!(f, "Unable to create a game since missing field(s)")
+                /*
+                write!(f, "Unable to create a game since command is missing fields:")?;
+                for field in missing_fields {
+                    write!(f, format!("{:?}", field))?;
+                }
+                Ok(())
+                 */
+            }
+            CreateGameError::AlreadyAtTable(table_name) => {
+                write!(
+                    f,
+                    "Unable to create a game since already at a table: {}",
+                    table_name
+                )
+            }
+            CreateGameError::InvalidFieldValue(invalid_field) => {
+                write!(
+                    f,
+                    "Unable to create a game since invalid field value: {}",
+                    invalid_field
+                )
+            }
+        }
     }
 }
-
 
 /// Session wants to create a game
 #[derive(Message)]


### PR DESCRIPTION
- new functionality that a table will not allow more than max_players players into the game
-  really big refactor where the GameHand struct is now simply owned by the Game. GameHand only stores things that are relevant for the current hand, e.g. flop, turn, river, pots, etc. All other fields, like the players, will continue to live in the Game. Now all the gamehand methods have been converted to Game methods. This lets us access the buy_in, the players, (eventually the password) from self, instead of needing to pass so many things around.
- we needed to use scoped threads now that the incoming actions and meta actions are a property on Games. This had the side-effect bonus of now being able to remove the Arc<> from the actions and simply pass in & references.
- I also ran cargo fmt for the first time in a while, hence all the changed files