### PR TITLE
Leave bug

### DIFF
--- a/src/logic/game.rs
+++ b/src/logic/game.rs
@@ -327,10 +327,26 @@ impl Game {
         player_config: PlayerConfig,
         player: Player,
     ) -> Result<usize, JoinGameError> {
+
+	// Kinda weird, but first check if the player is already at the table
+	// Could happen if their Leave wasn't completed yet
+	// TODO: verify this can actually happen. Unit testable even?
+        for (i, player_spot) in self.players.iter_mut().enumerate() {
+	    if let Some(existing) = player_spot {
+		if existing.id == player.id {
+		    println!("the player was ALREADY at the table!");
+                    self.player_ids_to_configs
+			.insert(player_config.id, player_config);
+		    return Ok(i);
+		}
+	    }
+	}
+	
         if self.players.iter().flatten().count() >= self.max_players.into() {
             // we already have as many as we can fit in the game
             return Err(JoinGameError::GameIsFull);
         }
+	    
         for (i, player_spot) in self.players.iter_mut().enumerate() {
             if player_spot.is_none() {
                 *player_spot = Some(player);

--- a/static/index.html
+++ b/static/index.html
@@ -555,7 +555,7 @@
 					    // want to clear the screen
 					    // TODO: how come the cards and players still show up Mike?
 					    drawTable(context, width, height);
-					    // Show Lobby
+					    // Show Lobby					    
 					    $gameMenu.style.display = "none";
 					    $lobbyMenu.style.display = "block";
 					    // have this log for now just for clarity. if the UI is more clear wont need?
@@ -678,11 +678,9 @@
 				msg["msg_type"] = "leave";
 
 				log("Sending: " + JSON.stringify(msg));
-				socket.send(JSON.stringify(msg));
-
-				// Show Lobby
-				$gameMenu.style.display = "none";
-				$lobbyMenu.style.display = "block";
+			    socket.send(JSON.stringify(msg));
+			    // note: we don't show the lobby until we get the confirmation from the game that we
+			    // actually left the game successfully
 			}
 
 			function sendMessage() {


### PR DESCRIPTION
- the main street loop now checks at the end whether a player is missing from the player config hashmap. This indicates that handle_meta_actions removed the config during the current player's action.
-  I also added some code to check when a player joins, are they already at the table and puts them right back in the same spot. Unclear if this is needed since I fixed the bug about not leaving, but maybe eventually this would even be a feature. Like a few seconds of grace if you leave? Like first sit_out for say 30 seconds, and the player can rejoin? Hmm
- on the front end, only show the lobby once we got confirmation that we left the game.