### PR TITLE
Admin commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,6 +1202,20 @@ name = "serde"
 version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.144"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ actix-web-actors = "4.1"
 
 env_logger = "0.9"
 log = "0.4"
-serde = "1"
+serde = {version = "1", features = ["derive"] }
 serde_json = "1"
 clap = { version = "4.0.32", features = ["derive"] }
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ A poker implementation written in Rust.
 
 The IO is implemented as a websocket server using the Actix framework.
 
-To run the server locally, use ```cargo run --bin server```. Then open a browser to local host for the playable front end UI. 
+To run the server locally, use ```cargo run```. Then open a browser to local host for the playable front end UI. 
 
-You can also use ```cargo run --bin server -- --help``` for more settings.
+You can also use ```cargo run -- --help``` for more settings.
 
 Example:
 
-```cargo run --bin server -- --ip 127.0.0.1 --port 8081```
+```cargo run -- --ip 127.0.0.1 --port 8081```

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -282,6 +282,7 @@ impl Handler<Create> for GameHub {
             return Err(CreateGameError::NameNotSet);
         }
 
+	// TODO: can this be better handled via serde??
         if let (
             Some(max_players),
             Some(small_blind),

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -373,6 +373,7 @@ impl Handler<Create> for GameHub {
                 big_blind,
                 buy_in,
                 password.clone(),
+		id, // the creator is the admin
             );
 
             for i in 0..num_bots {

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -291,7 +291,6 @@ impl Handler<Create> for GameHub {
 		    big_blind,
 		    buy_in,
 		    num_bots,
-		    is_private,
 		    password,
 		} = create_fields;
 		println!("password in create game = {:?}", password);
@@ -346,7 +345,8 @@ impl Handler<Create> for GameHub {
 			.expect("error adding bot on freshly created game");
 		}
 		
-		if is_private {
+		if password.is_some() {
+		    // a game with a password does not show up as a public game
                     self.private_tables.insert(table_name.clone());
 		}
 		

--- a/src/logic/game.rs
+++ b/src/logic/game.rs
@@ -1385,12 +1385,7 @@ impl Game {
             // the first thing we do on each loop is handle meta action
             // this lets us display messages in real-time without having to wait until after the
             // current player gives their action
-<<<<<<< HEAD
             self.handle_meta_actions(&incoming_meta_actions, between_hands);
-=======
-            self.handle_meta_actions(incoming_meta_actions);
->>>>>>> main
-
             if player.human_controlled {
                 // we don't need to count the attempts at getting a response from a computer
                 // TODO: the computer can give a better than random guess at a move
@@ -3184,8 +3179,6 @@ mod tests {
         assert!(game.players[0].is_none()); // the spot is empty now
         assert_eq!(game.players[1].as_ref().unwrap().money, 1008);
     }
-<<<<<<< HEAD
-
 
     /// if someone who is not the admin attempts an admin command, it does not work
     #[test]
@@ -3396,8 +3389,5 @@ mod tests {
         assert_eq!(game.player_ids_to_configs.len(), 2); // 2 player configs
 	// the player_ids_to_configs mapping no longer contains the id for the bot at index 0
 	assert!(game.players[0].as_ref().is_none());
-    }
-    
-=======
->>>>>>> main
+    }    
 }

--- a/src/logic/game.rs
+++ b/src/logic/game.rs
@@ -2748,7 +2748,7 @@ mod tests {
     /// the game should end after N hands if there are no human players in the game
     /// even if there is no hand limit or a high hand limit
     /// Note: in this test there are no players period, but the game will still count each check
-    /// as a hand "plsyed", so we can check that the game ends with the proper count
+    /// as a hand "played", so we can check that the game ends with the proper count
     #[test]
     fn end_early() {
         let mut game = Game::default();

--- a/src/logic/game.rs
+++ b/src/logic/game.rs
@@ -556,7 +556,7 @@ impl Game {
 	    AdminCommand::SmallBlind(new) => {
 		self.small_blind = new;
 		object! {
-		    msg_type: "update_success".to_owned(),
+		    msg_type: "admin_success".to_owned(),
 		    updated: "small_blind".to_owned(),
                     text: format!("The small blind has been changed to {}", new),
 		}
@@ -564,7 +564,7 @@ impl Game {
 	    AdminCommand::BigBlind(new) => {
 		self.big_blind = new;
 		object! {
-		    msg_type: "update_success".to_owned(),
+		    msg_type: "admin_success".to_owned(),
 		    updated: "small_blind".to_owned(),
                     text: format!("The small blind has been changed to {}", new),
 		}
@@ -572,7 +572,7 @@ impl Game {
 	    AdminCommand::BuyIn(new) => {
 		self.buy_in = new;
 		object! {
-		    msg_type: "update_success".to_owned(),
+		    msg_type: "admin_success".to_owned(),
 		    updated: "buy_in".to_owned(),
                     text: format!("The buy in has been changed to {}", new),
 		}
@@ -580,7 +580,7 @@ impl Game {
 	    AdminCommand::Password(new) => {
 		self.password = Some(new.clone());
 		object! {
-		    msg_type: "update_success".to_owned(),
+		    msg_type: "admin_success".to_owned(),
 		    updated: "password".to_owned(),
                     text: format!("The password has been changed to {}", new),
 		}
@@ -589,7 +589,7 @@ impl Game {
 		match self.add_bot("Bot".to_string()) {
 		    Ok(_) => {
 			object! {
-			    msg_type: "update_success".to_owned(),
+			    msg_type: "admin_success".to_owned(),
 			    updated: "bot_added".to_owned(),
 			    text: "A bot has been added.".to_owned(),
 			}
@@ -621,7 +621,7 @@ impl Game {
 		}
 		if found {
 		    object! {
-			msg_type: "update_success".to_owned(),
+			msg_type: "admin_success".to_owned(),
 			updated: "bot_removed".to_owned(),
 			text: "A bot has been removed.".to_owned(),		    
 		    }

--- a/src/logic/game.rs
+++ b/src/logic/game.rs
@@ -527,6 +527,7 @@ impl Game {
 		MetaAction::Admin(id, admin_command) => {
 		    if !between_hands {
 			// put it back on the meta actions queue to be handled only between hands
+			println!("put the admin_command back on the queue to handle between hands");
 			meta_actions.push_back(MetaAction::Admin(id, admin_command));
 		    } else {
 			self.handle_admin_command(id, admin_command);
@@ -537,6 +538,7 @@ impl Game {
     }
 
     fn handle_admin_command(&mut self, id: Uuid, admin_command: AdminCommand) {
+	println!("handling admin_command in game: {:?}", admin_command);
 	if self.admin_id != id {
 	    // the player who entered the admin command is not the game's admin!
 	    let message = object! {
@@ -580,8 +582,8 @@ impl Game {
 		self.big_blind = new;
 		object! {
 		    msg_type: "admin_success".to_owned(),
-		    updated: "small_blind".to_owned(),
-                    text: format!("The small blind has been changed to {}", new),
+		    updated: "big_blind".to_owned(),
+                    text: format!("The big blind has been changed to {}", new),
 		}
 	    }		
 	    AdminCommand::BuyIn(new) => {
@@ -609,11 +611,11 @@ impl Game {
 			    text: "A bot has been added.".to_owned(),
 			}
 		    }
-		    Err(_) => {
+		    Err(err) => {
 			object! {
 			    msg_type: "error".to_owned(),
 			    error: "unable_to_add_bot".to_owned(),
-			    reason: "Unable to add bot to the game.".to_owned(),
+			    reason: err.to_string(),
 			}
 		    }
 		}

--- a/src/logic/game.rs
+++ b/src/logic/game.rs
@@ -556,32 +556,32 @@ impl Game {
 	    AdminCommand::SmallBlind(new) => {
 		self.small_blind = new;
 		object! {
-		    msg_type: "admin_change".to_owned(),
-		    change: "small_blind".to_owned(),
+		    msg_type: "update_success".to_owned(),
+		    updated: "small_blind".to_owned(),
                     text: format!("The small blind has been changed to {}", new),
 		}
 	    },
 	    AdminCommand::BigBlind(new) => {
 		self.big_blind = new;
 		object! {
-		    msg_type: "admin_change".to_owned(),
-		    change: "small_blind".to_owned(),
+		    msg_type: "update_success".to_owned(),
+		    updated: "small_blind".to_owned(),
                     text: format!("The small blind has been changed to {}", new),
 		}
 	    }		
 	    AdminCommand::BuyIn(new) => {
 		self.buy_in = new;
 		object! {
-		    msg_type: "admin_change".to_owned(),
-		    change: "buy_in".to_owned(),
+		    msg_type: "update_success".to_owned(),
+		    updated: "buy_in".to_owned(),
                     text: format!("The buy in has been changed to {}", new),
 		}
 	    }		
 	    AdminCommand::Password(new) => {
 		self.password = Some(new.clone());
 		object! {
-		    msg_type: "admin_change".to_owned(),
-		    change: "password".to_owned(),
+		    msg_type: "update_success".to_owned(),
+		    updated: "password".to_owned(),
                     text: format!("The password has been changed to {}", new),
 		}
 	    }
@@ -589,8 +589,8 @@ impl Game {
 		match self.add_bot("Bot".to_string()) {
 		    Ok(_) => {
 			object! {
-			    msg_type: "admin_change".to_owned(),
-			    change: "bot_added".to_owned(),
+			    msg_type: "update_success".to_owned(),
+			    updated: "bot_added".to_owned(),
 			    text: "A bot has been added.".to_owned(),
 			}
 		    }
@@ -621,15 +621,15 @@ impl Game {
 		}
 		if found {
 		    object! {
-			msg_type: "admin_change".to_owned(),
-			change: "bot_removed".to_owned(),
+			msg_type: "update_success".to_owned(),
+			updated: "bot_removed".to_owned(),
 			text: "A bot has been removed.".to_owned(),		    
 		    }
 		} else {
 		    object! {
 			msg_type: "error".to_owned(),
-			error: "unable_to_add_bot".to_owned(),
-			reason: "Unable to add bot to the game.".to_owned(),
+			error: "unable_to_remove_bot".to_owned(),
+			reason: "Unable to remove a bot from the game.".to_owned(),
 		    }
 		}
 	    }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -15,7 +15,7 @@ pub enum MetaAction {
     SitOut(Uuid),
     PlayerName(Uuid, String),
     Chat(Uuid, String),
-    Admin(AdminCommand),
+    Admin(Uuid, AdminCommand),
 }
 
 /// these admin commands can be taken by the owner of a PRIVATE game.
@@ -23,13 +23,13 @@ pub enum MetaAction {
 /// The Uuid of the player attemping an admin command must actually be the game.admin to work
 #[derive(Debug)]
 pub enum AdminCommand {
-    SmallBlind(Uuid, u32),
-    BigBlind(Uuid, u32),
-    BuyIn(Uuid, u32),
-    Password(Uuid, String),
-    AddBot(Uuid),
-    RemoveBot(Uuid),
-    // NewAdmin(Uuid, Uuid), // todo? would they give the name of the player or what?
+    SmallBlind(u32),
+    BigBlind(u32),
+    BuyIn(u32),
+    Password(String),
+    AddBot,
+    RemoveBot,
+    // NewAdmin(Uuid), // todo? would they give the name of the player or what?
 }
 
 #[derive(Message)]

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -4,7 +4,6 @@ use serde_json::Value;
 use std::fmt;
 use uuid::Uuid;
 
-/// Game server sends this messages to session
 
 /// this enum represents higher level commands that the hub will relay
 /// to the running games Player name change. player join/leave
@@ -16,6 +15,21 @@ pub enum MetaAction {
     SitOut(Uuid),
     PlayerName(Uuid, String),
     Chat(Uuid, String),
+    Admin(AdminCommand),
+}
+
+/// these admin commands can be taken by the owner of a PRIVATE game.
+/// commands to change the blinds, buy in, password, and to add or remove bots
+/// The Uuid of the player attemping an admin command must actually be the game.admin to work
+#[derive(Debug)]
+pub enum AdminCommand {
+    SmallBlind(Uuid, u32),
+    BigBlind(Uuid, u32),
+    BuyIn(Uuid, u32),
+    Password(Uuid, String),
+    AddBot(Uuid),
+    RemoveBot(Uuid),
+    // NewAdmin(Uuid, Uuid), // todo? would they give the name of the player or what?
 }
 
 #[derive(Message)]

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -158,7 +158,6 @@ pub struct CreateFields {
     pub big_blind: u32,
     pub buy_in: u32,
     pub num_bots: u8,
-    pub is_private: bool,
     pub password: Option<String>,
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -386,16 +386,19 @@ impl WsGameSession {
         if let Some(Value::String(admin_command)) = object.get("admin_command") {
             let invalid_json =  match admin_command.as_str() {
                 "small_blind" => {
-		    if let Some(Value::String(amount)) = object.get("small__blind") {
-			let amount = amount.to_string();
-			self.hub_addr.do_send(messages::MetaActionMessage {
-			    id: self.id,
-			    meta_action: messages::MetaAction::Admin(
-				self.id,				
-				messages::AdminCommand::SmallBlind(amount.parse::<u32>().unwrap()),
-			    )
-			});
-			false
+		    if let Some(Value::String(amount)) = object.get("small_blind") {
+			if let Ok(amount) = amount.to_string().parse::<u32>() {
+			    self.hub_addr.do_send(messages::MetaActionMessage {
+				id: self.id,
+				meta_action: messages::MetaAction::Admin(
+				    self.id,				
+				    messages::AdminCommand::SmallBlind(amount),
+				)
+			    });
+			    false
+			} else {
+			    true
+			}
 		    } else {
 			// invalid_json
 			true
@@ -403,15 +406,18 @@ impl WsGameSession {
                 }
                 "big_blind" => {
 		    if let Some(Value::String(amount)) = object.get("big_blind") {
-			let amount = amount.to_string();
-			self.hub_addr.do_send(messages::MetaActionMessage {
-			    id: self.id,
-			    meta_action: messages::MetaAction::Admin(
-				self.id,				
-				messages::AdminCommand::BigBlind(amount.parse::<u32>().unwrap()),
-			    )
-			});
-			false
+			if let Ok(amount) = amount.to_string().parse::<u32>() {			
+			    self.hub_addr.do_send(messages::MetaActionMessage {
+				id: self.id,
+				meta_action: messages::MetaAction::Admin(
+				    self.id,				
+				    messages::AdminCommand::BigBlind(amount),
+				)
+			    });
+			    false			    
+			} else {
+			    true
+			}
 		    } else {
 			// invalid_json			
 			true
@@ -419,15 +425,18 @@ impl WsGameSession {
                 }
                 "buy_in" => {
 		    if let Some(Value::String(amount)) = object.get("buy_in") {
-			let amount = amount.to_string();
-			self.hub_addr.do_send(messages::MetaActionMessage {
-			    id: self.id,
-			    meta_action: messages::MetaAction::Admin(
-				self.id,				
-				messages::AdminCommand::BuyIn(amount.parse::<u32>().unwrap()),
-			    )
-			});
-			false
+			if let Ok(amount) = amount.to_string().parse::<u32>() {	
+			    self.hub_addr.do_send(messages::MetaActionMessage {
+				id: self.id,
+				meta_action: messages::MetaAction::Admin(
+				    self.id,				
+				    messages::AdminCommand::BuyIn(amount),
+				)
+			    });
+			    false
+			} else {
+			    true
+			}
 		    } else {
 			// invalid json
 			true
@@ -440,7 +449,7 @@ impl WsGameSession {
 			    id: self.id,
 			    meta_action: messages::MetaAction::Admin(
 				self.id,				
-				messages::AdminCommand::BigBlind(amount.parse::<u32>().unwrap()),
+				messages::AdminCommand::Password(amount),
 			    )
 			});
 			false

--- a/static/index.html
+++ b/static/index.html
@@ -663,8 +663,6 @@
 			var msg = {}; // build the json to send
 			msg["msg_type"] = "name";
 			msg["player_name"] = $playerName.value;
-
-			//log("Sending: " + JSON.stringify(msg));
 			socket.send(JSON.stringify(msg));
 		}
 
@@ -673,15 +671,12 @@
 			msg["msg_type"] = "join";
 			msg["table_name"] = $tableId.value;
 			msg["password"] = "123";
-			//log("Sending: " + JSON.stringify(msg));
 			socket.send(JSON.stringify(msg));
 		}
 
 		function listPublicTable() {
 			var msg = {}; // build the json to send
 			msg["msg_type"] = "list";
-
-			//log("Sending: " + JSON.stringify(msg));
 			socket.send(JSON.stringify(msg));
 		}
 
@@ -693,7 +688,6 @@
 			msg["small_blind"] = parseInt($smallBlindValue.value);
 			msg["big_blind"] = parseInt($bigBlindValue.value);
 		        msg["buy_in"] = parseInt($startingStackValue.value);
-			msg["is_private"] = false;
 		    msg["password"] = null;
 			//log("Sending: " + JSON.stringify(msg));
 			socket.send(JSON.stringify(msg));
@@ -724,14 +718,49 @@
 		function sendMessage() {
 			var msg = {}; // build the json to send
 
+		    // first check if it starts with an admin command attempt
+		    if ($input.value.startsWith("/small_blind")) {
+			msg["msg_type"] = "admin_command";
+			const [_, value] = $input.value.split(" ");
+			msg["admin_command"] = "small_blind";
+			msg["small_blind"] = value;
+			
+		    }
+		    else if ($input.value.startsWith("/big_blind")) {
+			msg["msg_type"] = "admin_command";
+			const [_, value] = $input.value.split(" ");
+			msg["admin_command"] = "big_blind";
+			msg["big_blind"] = value;
+			
+		    }
+		    else if ($input.value.startsWith("/buy_in")) {
+			msg["msg_type"] = "admin_command";
+			msg["admin_command"] = "buy_in";
+			msg["buy_in"] = value;
+		    }
+		    else if ($input.value.startsWith("/password")) {
+			msg["msg_type"] = "admin_command";
+			const [_, value] = $input.value.split(" ");
+			msg["admin_command"] = "password";
+			msg["password"] = value;
+		    }
+		    else if ($input.value.startsWith("/add_bot")) {
+			msg["msg_type"] = "admin_command";
+			msg["admin_command"] = "add_bot";
+		    }
+		    else if ($input.value.startsWith("/remove_bot")) {
+			msg["msg_type"] = "admin_command";
+			msg["admin_command"] = "remove_bot";			
+		    }
+		    else {
 			msg["msg_type"] = "chat";
 			msg["text"] = $input.value;
-
-			log("Sending: " + JSON.stringify(msg));
-			socket.send(JSON.stringify(msg));
-
-			$input.value = "";
-			$input.focus();
+		    }
+		    log("Sending: " + JSON.stringify(msg));
+		    socket.send(JSON.stringify(msg));
+		    
+		    $input.value = "";
+		    $input.focus();
 		}
 
 		$form.addEventListener("submit", (ev) => {

--- a/static/index.html
+++ b/static/index.html
@@ -614,6 +614,8 @@
 						log(ev.data, "message");
 					} else if (msg.msg_type == "error") {
 					    log(msg.error + ": " + msg.reason, "message");	
+					} else if (msg.msg_type == "admin_success") {
+					    log(msg.msg_type + ": " + msg.text, "message");	
 					} else {
 						log("We are not handling this message properly!", "message");
 					}
@@ -688,7 +690,7 @@
 			msg["small_blind"] = parseInt($smallBlindValue.value);
 			msg["big_blind"] = parseInt($bigBlindValue.value);
 		        msg["buy_in"] = parseInt($startingStackValue.value);
-		    msg["password"] = null;
+		    msg["password"] = "123";
 			//log("Sending: " + JSON.stringify(msg));
 			socket.send(JSON.stringify(msg));
 		}
@@ -756,7 +758,11 @@
 			msg["msg_type"] = "chat";
 			msg["text"] = $input.value;
 		    }
+
 		    log("Sending: " + JSON.stringify(msg));
+		    if (msg["msg_type"] == "admin_command") {
+			log("admin commands are handled at the end of the current hand");
+		    }
 		    socket.send(JSON.stringify(msg));
 		    
 		    $input.value = "";

--- a/static/index.html
+++ b/static/index.html
@@ -692,9 +692,9 @@
 			msg["num_bots"] = parseInt($botNumberSlider.value);
 			msg["small_blind"] = parseInt($smallBlindValue.value);
 			msg["big_blind"] = parseInt($bigBlindValue.value);
-			msg["buy_in"] = parseInt($startingStackValue.value);
+		        msg["buy_in"] = parseInt($startingStackValue.value);
 			msg["is_private"] = false;
-			msg["password"] = "123";
+		    msg["password"] = null;
 			//log("Sending: " + JSON.stringify(msg));
 			socket.send(JSON.stringify(msg));
 		}


### PR DESCRIPTION
- now the admin (person who created) password-protected games can update the small_blind, big_blind, buy_in, password, and add or remove bots from a current game. 
-  the front end parses the commands from the text box into the  expected json commands.
    - e.g. "/big_blind 24"
    
-  the admin commands are handled at the end of the current hand
- if a user who is not the admin attempts this, it won't work.

- I also refactored the hub to handle create game messages using serde de-serialization. This was a lot nicer/cleaner than how I was doing it before. We COULD change all commands to be like that, but I think the boilerplate tradeoff becomes more useful for larger commands only