### PR TITLE
Self destruct

### DIFF
--- a/src/hub.rs
+++ b/src/hub.rs
@@ -409,7 +409,7 @@ impl Handler<Create> for GameHub {
             println!("create message missing one or more required fields!");
             self.main_lobby_connections
                 .insert(player_config.id, player_config);
-            return Err(CreateGameError::MissingField);
+            Err(CreateGameError::MissingField)
         }
     }
 }

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -11,7 +11,7 @@ use std::{
 
 use crate::logic::{Game, PlayerAction, PlayerConfig};
 use crate::messages::{
-    Connect, Create, CreateGameError, Join, ListTables, MetaAction, MetaActionMessage,
+    Connect, Create, CreateGameError, GameOver, Join, ListTables, MetaAction, MetaActionMessage,
     PlayerActionMessage, PlayerName, Returned, ReturnedReason, WsMessage,
 };
 use actix::prelude::{Actor, Context, Handler, MessageResult};
@@ -434,6 +434,26 @@ impl Handler<PlayerActionMessage> for GameHub {
                 println!("blah blah mp actioms queue!");
             }
         }
+    }
+}
+
+/// the game tells us that it has ended (no more human players),
+/// so lets remove it from our hub records
+impl Handler<GameOver> for GameHub {
+    type Result = ();
+
+    fn handle(&mut self, msg: GameOver, _: &mut Context<Self>) {
+        let GameOver { table_name } = msg;
+        println!("Handling game over in the hub for table name: {:?}", table_name);
+	if self.tables_to_actions.remove(&table_name).is_some() {
+	    println!("removed properly from tables_to_actions");
+	}
+	if self.tables_to_meta_actions.remove(&table_name).is_some() {
+	    println!("removed properly from tables_to_meta_actions");
+	}
+	if self.private_tables.remove(&table_name) {
+	    println!("removed properly from private_tables");
+	}	
     }
 }
 

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -172,16 +172,15 @@ impl Handler<Join> for GameHub {
         if player_config.name.is_none() {
             // they are not allowed to join a game without a Name set
             let message = json::object! {
-                msg_type: "error".to_owned(),
-		error: "unable_to_join".to_owned(),
-                reason: "You cannot join a game until you set your name!"
-            };
+                    msg_type: "error".to_owned(),
+            error: "unable_to_join".to_owned(),
+                    reason: "You cannot join a game until you set your name!"
+                };
             player_config
                 .player_addr
                 .as_ref()
                 .unwrap()
-                .do_send(WsMessage(message.dump()                    
-                ));
+                .do_send(WsMessage(message.dump()));
             // put them back in the lobby
             self.main_lobby_connections
                 .insert(player_config.id, player_config);
@@ -201,10 +200,10 @@ impl Handler<Join> for GameHub {
                 .push_back(MetaAction::Join(player_config, password));
         } else {
             let message = json::object! {
-                msg_type: "error".to_owned(),
-		error: "unable_to_join".to_owned(),
-                reason: format!("no table named {} exisits", table_name),
-            };
+                    msg_type: "error".to_owned(),
+            error: "unable_to_join".to_owned(),
+                    reason: format!("no table named {} exisits", table_name),
+                };
             player_config
                 .player_addr
                 .as_ref()
@@ -332,16 +331,18 @@ impl Handler<Create> for GameHub {
                 None
             };
 
-	    if num_bots >= max_players {
-		self.main_lobby_connections.insert(player_config.id, player_config);
-		return Err(CreateGameError::TooManyBots);
-	    }
+            if num_bots >= max_players {
+                self.main_lobby_connections
+                    .insert(player_config.id, player_config);
+                return Err(CreateGameError::TooManyBots);
+            }
 
-	    if big_blind > buy_in || small_blind > buy_in {
-		self.main_lobby_connections.insert(player_config.id, player_config);
-		return Err(CreateGameError::TooLargeBlinds);		
-	    }
-	    
+            if big_blind > buy_in || small_blind > buy_in {
+                self.main_lobby_connections
+                    .insert(player_config.id, player_config);
+                return Err(CreateGameError::TooLargeBlinds);
+            }
+
             let mut rng = rand::thread_rng();
             let table_name = loop {
                 // create a new 4-char unique name for the table
@@ -406,7 +407,8 @@ impl Handler<Create> for GameHub {
             Ok(table_name) // return the table name
         } else {
             println!("create message missing one or more required fields!");
-	    self.main_lobby_connections.insert(player_config.id, player_config);	    
+            self.main_lobby_connections
+                .insert(player_config.id, player_config);
             return Err(CreateGameError::MissingField);
         }
     }
@@ -444,16 +446,19 @@ impl Handler<GameOver> for GameHub {
 
     fn handle(&mut self, msg: GameOver, _: &mut Context<Self>) {
         let GameOver { table_name } = msg;
-        println!("Handling game over in the hub for table name: {:?}", table_name);
-	if self.tables_to_actions.remove(&table_name).is_some() {
-	    println!("removed properly from tables_to_actions");
-	}
-	if self.tables_to_meta_actions.remove(&table_name).is_some() {
-	    println!("removed properly from tables_to_meta_actions");
-	}
-	if self.private_tables.remove(&table_name) {
-	    println!("removed properly from private_tables");
-	}	
+        println!(
+            "Handling game over in the hub for table name: {:?}",
+            table_name
+        );
+        if self.tables_to_actions.remove(&table_name).is_some() {
+            println!("removed properly from tables_to_actions");
+        }
+        if self.tables_to_meta_actions.remove(&table_name).is_some() {
+            println!("removed properly from tables_to_meta_actions");
+        }
+        if self.private_tables.remove(&table_name) {
+            println!("removed properly from private_tables");
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,13 +21,13 @@ mod session;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-   /// ip address
-   #[arg(short, long, default_value_t = ("localhost".to_string()))]
-   ip: String,
+    /// ip address
+    #[arg(short, long, default_value_t = ("localhost".to_string()))]
+    ip: String,
 
-   /// port
-   #[arg(short, long, default_value_t = 8080)]
-   port: u16,
+    /// port
+    #[arg(short, long, default_value_t = 8080)]
+    port: u16,
 }
 
 async fn index() -> impl Responder {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -110,10 +110,7 @@ impl fmt::Display for CreateGameError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             CreateGameError::NameNotSet => {
-                write!(
-                    f,
-                    "You have not set your name"
-                )
+                write!(f, "You have not set your name")
             }
             CreateGameError::MissingField => {
                 write!(f, "Missing field(s)")
@@ -129,11 +126,7 @@ impl fmt::Display for CreateGameError {
                 write!(f, "You are already at the table {}", table_name)
             }
             CreateGameError::InvalidFieldValue(invalid_field) => {
-                write!(
-                    f,
-                    "Invalid field value: {}",
-                    invalid_field
-                )
+                write!(f, "Invalid field value: {}", invalid_field)
             }
             CreateGameError::TooManyBots => {
                 write!(f, "Too many bots selected")

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -163,6 +163,13 @@ pub struct PlayerActionMessage {
     pub player_action: PlayerAction,
 }
 
+/// the hub learns that a game has ended
+#[derive(Message)]
+#[rtype(result = "()")]
+pub struct GameOver {
+    pub table_name: String,
+}
+
 #[derive(Message)]
 #[rtype(result = "()")]
 pub struct MetaActionMessage {

--- a/src/session.rs
+++ b/src/session.rs
@@ -302,7 +302,6 @@ impl WsGameSession {
         } else {
             println!("missing table name or password!");
             ctx.text("!!! table_name and password (possibly null) are required");
-            return;
         }
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -240,10 +240,10 @@ impl WsGameSession {
                         Err(e) => {
                             println!("{}", e);
                             let message = json::object! {
-                                msg_type: "error".to_owned(),
-				error: "unable_to_create".to_owned(),
-                                reason: e.to_string(),
-                            };
+                                            msg_type: "error".to_owned(),
+                            error: "unable_to_create".to_owned(),
+                                            reason: e.to_string(),
+                                        };
                             ctx.text(message.dump());
                         }
                     },


### PR DESCRIPTION
- games now count how many turns they played without at least one human_controlled player in them, and once this reaches a predefined constant, the game ends early (rather than running indefinitely).
- when a game ends the play() method, it returns a new GameOver message to the game hub, who removes all records of this game from its mappings.
- since the thread for each game is spawned on the play() method, the thread will also be cleaned up after the game ends.