### PR TITLE
More admin

### DIFF
--- a/src/logic/game.rs
+++ b/src/logic/game.rs
@@ -8,7 +8,7 @@ use super::card::{Card, Deck, HandResult, StandardDeck};
 use super::player::{Player, PlayerAction, PlayerConfig};
 use crate::hub::GameHub;
 
-use crate::messages::{get_help_message, AdminCommand, GameOver, JoinGameError, MetaAction, Returned, ReturnedReason};
+use crate::messages::{AdminCommand, GameOver, JoinGameError, MetaAction, Returned, ReturnedReason};
 
 use std::{cmp, iter, sync::Arc, thread, time};
 
@@ -477,16 +477,7 @@ impl Game {
                             };
 
                     PlayerConfig::send_group_message(&message.dump(), &self.player_ids_to_configs);
-                }
-                MetaAction::Help(id) => {
-                    // send the help message to the player who requested it
-                    let message = object! {
-			msg_type: "help".to_owned(),
-			text: get_help_message(),
-                    };
-                    PlayerConfig::send_specific_message(&message.dump(), id, &self.player_ids_to_configs);
-                }
-		
+                }		
                 MetaAction::Join(player_config, password) => {
                     // add a new player to the game
                     let cloned_config = player_config.clone(); // clone in case we need to send back
@@ -1126,11 +1117,6 @@ impl Game {
         // iterate over the players from the starting index to the end of the vec,
         // and then from the beginning back to the starting index
         for i in (starting_idx..9).chain(0..starting_idx).cycle() {
-            /*
-            println!(
-                "start loop index = {}: num_active = {}, num_settled = {}, num_all_in = {}",
-                i, num_active, num_settled, num_all_in
-            );*/
             if num_active == 1 {
                 println!("Only one active player left so lets break the steet loop");
                 // end the street and indicate to the caller that the hand is finished

--- a/src/logic/game.rs
+++ b/src/logic/game.rs
@@ -419,6 +419,11 @@ impl Game {
             }
 	    let between_hands = true;
             self.handle_meta_actions(&incoming_meta_actions, between_hands);
+            // wait for next hand
+	    // this is especially needed when there is only one player in the game
+            let wait_duration = time::Duration::from_secs(1);
+            thread::sleep(wait_duration);
+	    
         }
         println!("about to send the gameover signal to the hub");
         // the game is ending, so tell that to the hub

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -14,6 +14,7 @@ pub enum MetaAction {
     SitOut(Uuid),
     PlayerName(Uuid, String),
     Chat(Uuid, String),
+    Help(Uuid),
     Admin(Uuid, AdminCommand),
 }
 
@@ -28,7 +29,13 @@ pub enum AdminCommand {
     Password(String),
     AddBot,
     RemoveBot,
+    Restart,
     // NewAdmin(Uuid), // todo? would they give the name of the player or what?
+}
+
+    
+pub fn get_help_message() -> String {
+    "/small_blind X\n/big_blind X\n/buy_in X\n/password X\n/add_bot\n/remove_bot".to_string()
 }
 
 #[derive(Message)]

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -14,7 +14,6 @@ pub enum MetaAction {
     SitOut(Uuid),
     PlayerName(Uuid, String),
     Chat(Uuid, String),
-    Help(Uuid),
     Admin(Uuid, AdminCommand),
 }
 
@@ -31,11 +30,6 @@ pub enum AdminCommand {
     RemoveBot,
     Restart,
     // NewAdmin(Uuid), // todo? would they give the name of the player or what?
-}
-
-    
-pub fn get_help_message() -> String {
-    "/small_blind X\n/big_blind X\n/buy_in X\n/password X\n/add_bot\n/remove_bot".to_string()
 }
 
 #[derive(Message)]

--- a/src/session.rs
+++ b/src/session.rs
@@ -18,6 +18,15 @@ const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 /// How long before lack of client response causes a timeout
 const CLIENT_TIMEOUT: Duration = Duration::from_secs(10);
 
+pub fn get_help_message() -> Vec<String> {
+    vec!["/small_blind X".to_string(),
+	 "/big_blind X".to_string(),
+	 "/buy_in X".to_string(),
+	 "/password X".to_string(),
+	 "/add_bot".to_string(),
+	 "/remove_bot".to_string()]
+}
+
 #[derive(Debug)]
 pub struct WsGameSession {
     /// unique session id
@@ -217,6 +226,13 @@ impl WsGameSession {
                 "chat" => {
                     self.handle_chat(object, ctx);
                 }
+		"help" => {
+                    let message = json::object! {
+			msg_type: "help_message".to_owned(),
+			commands: get_help_message(),
+                    };
+                    ctx.text(message.dump());
+		}
                 _ => ctx.text(format!("!!! unknown command: {:?}", object)),
             },
             _ => ctx.text(format!("!!! improper msg_type in: {:?}", object)),
@@ -473,6 +489,15 @@ impl WsGameSession {
 			meta_action: messages::MetaAction::Admin(
 			    self.id,				
 			    messages::AdminCommand::RemoveBot),
+                    });
+		    false
+                }
+                "restart" => {
+		    self.hub_addr.do_send(messages::MetaActionMessage {
+			id: self.id,
+			meta_action: messages::MetaAction::Admin(
+			    self.id,				
+			    messages::AdminCommand::Restart),
                     });
 		    false
                 }

--- a/static/index.html
+++ b/static/index.html
@@ -754,6 +754,10 @@
 			msg["msg_type"] = "admin_command";
 			msg["admin_command"] = "remove_bot";			
 		    }
+		    else if ($input.value.startsWith("/restart")) {
+			msg["msg_type"] = "admin_command";
+			msg["admin_command"] = "restart";			
+		    }
 		    else {
 			msg["msg_type"] = "chat";
 			msg["text"] = $input.value;

--- a/static/index.html
+++ b/static/index.html
@@ -614,6 +614,11 @@
 						log(ev.data, "message");
 					} else if (msg.msg_type == "error") {
 					    log(msg.error + ": " + msg.reason, "message");	
+					} else if (msg.msg_type == "help_message") {
+					    log("Available admin commands:", "message");
+					    for (const cmd of msg.commands) {
+						log(cmd, "message");
+					    }
 					} else if (msg.msg_type == "admin_success") {
 					    log(msg.msg_type + ": " + msg.text, "message");	
 					} else {
@@ -757,6 +762,9 @@
 		    else if ($input.value.startsWith("/restart")) {
 			msg["msg_type"] = "admin_command";
 			msg["admin_command"] = "restart";			
+		    }
+		    else if ($input.value.startsWith("/help")) {
+			msg["msg_type"] = "help";
 		    }
 		    else {
 			msg["msg_type"] = "chat";


### PR DESCRIPTION
- adding the /restart and /help commands
-  /help prints out a list of available admin commands (only the admin can apply them, of course)
- /restart sets all the players to have their money at the buy_in amount after the current hand
- also fixed the problem where a game with a  single player was "stuck". You can now add  a bot and get going.