### PR TITLE
sitting out doesnt stop ur blinds from being harvested

### DIFF
--- a/src/hub.rs
+++ b/src/hub.rs
@@ -10,7 +10,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::logic::{Game, PlayerAction, PlayerConfig, PLAYER_TIMEOUT};
+use crate::logic::{Game, PlayerAction, PlayerConfig};
 use crate::messages::{
     Connect, Create, CreateFields, CreateGameError, GameOver, Join, ListTables, MetaAction, MetaActionMessage,
     PlayerActionMessage, PlayerName, Returned, ReturnedReason, WsMessage,

--- a/src/session.rs
+++ b/src/session.rs
@@ -148,12 +148,7 @@ impl Actor for WsPlayerSession {
     }
 
     fn stopping(&mut self, _: &mut Self::Context) -> Running {
-	println!("im 'stopping' inside Actor");
         Running::Stop
-    }
-    
-    fn stopped(&mut self, _: &mut Self::Context) {
-	println!("im 'stopped' inside Actor");
     }
 }
 


### PR DESCRIPTION
- even if a playing is sitting out, they still will pay the small and big blind before then folding the hand.
- i also was able to remove the clone() of the player object inside play_street. player borrows now happen inside specific scopes. I am not sure if this is common now and then in rust, or if i coded myself into a corner on the high level design, but it works, and i like that I dont have the clone() anymore.