### PR TITLE
Game refactor

### DIFF
--- a/src/hub.rs
+++ b/src/hub.rs
@@ -6,7 +6,7 @@
 
 use std::{
     collections::{HashMap, HashSet, VecDeque},
-    sync::{atomic::AtomicUsize, Arc, Mutex},
+    sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
 
@@ -41,20 +41,17 @@ pub struct GameHub {
 
     private_tables: HashSet<String>, // which games do not show up in the loby
 
-    visitor_count: Arc<AtomicUsize>,
+    //visitor_count: Arc<AtomicUsize>,
 }
 
 impl GameHub {
-    pub fn new(visitor_count: Arc<AtomicUsize>) -> GameHub {
+    pub fn new() -> GameHub {
         GameHub {
-            //sessions: HashMap::new(),
-            //tables_to_session_ids: HashMap::new(),
             main_lobby_connections: HashMap::new(),
             players_to_table: HashMap::new(),
             tables_to_actions: HashMap::new(),
             tables_to_meta_actions: HashMap::new(),
             private_tables: HashSet::new(),
-            visitor_count,
         }
     }    
 }

--- a/src/logic/card.rs
+++ b/src/logic/card.rs
@@ -1,11 +1,9 @@
-use rand::seq::SliceRandom; // for shuffling a vec
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
 ///
 /// This file contains structs/enums/methods for defining, using, and comparing cards and hands of cards
 ///
-use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Copy, Clone, EnumIter, Hash)]
@@ -368,55 +366,6 @@ impl HandResult {
     }
 }
 
-    /// Given a player, we need to determine which 5 cards make the best hand for this player
-    fn determine_best_hand(&self, player: &Player, gamehand: &mut GameHand) -> Option<HandResult> {
-        if !player.is_active {
-            // if the player isn't active, then can't have a best hand
-            return None;
-        }
-
-        if let Street::ShowDown = gamehand.street {
-            // we look at all possible 7 choose 5 (21) hands from the hole cards, flop, turn, river
-            let mut best_result: Option<HandResult> = None;
-            let mut hand_count = 0;
-            for exclude_idx1 in 0..7 {
-                //println!("exclude 1 = {}", exclude_idx1);
-                for exclude_idx2 in exclude_idx1 + 1..7 {
-                    //println!("exclude 2 = {}", exclude_idx2);
-                    let mut possible_hand = Vec::with_capacity(5);
-                    hand_count += 1;
-                    for (idx, card) in player
-                        .hole_cards
-                        .iter()
-                        .chain(gamehand.flop.as_ref().unwrap().iter())
-                        .chain(iter::once(&gamehand.turn.unwrap()))
-                        .chain(iter::once(&gamehand.river.unwrap()))
-                        .enumerate()
-                    {
-                        if idx != exclude_idx1 && idx != exclude_idx2 {
-                            //println!("pushing!");
-                            possible_hand.push(*card);
-                        }
-                    }
-                    // we have built a hand of five cards, now evaluate it
-                    let current_result = HandResult::analyze_hand(possible_hand);
-                    match best_result {
-                        None => best_result = Some(current_result),
-                        Some(result) if current_result > result => {
-                            best_result = Some(current_result)
-                        }
-                        _ => (),
-                    }
-                }
-            }
-            assert!(hand_count == 21); // 7 choose 5
-            println!("player = {:?}", player.id);
-            println!("best result = {:?}", best_result);
-            best_result
-        } else {
-            None
-        }
-    }
 
 
 #[cfg(test)]

--- a/src/logic/deck.rs
+++ b/src/logic/deck.rs
@@ -1,3 +1,11 @@
+use rand::seq::SliceRandom; // for shuffling a vec
+
+use super::card::{Card, Rank, Suit};
+
+///
+/// This file contains structs/enums/methods for defining, using, and comparing cards and hands of cards
+///
+use strum::IntoEnumIterator;
 
 /// trait to define behaviour that you would expect out of a deck of cards
 /// in unit tests, we may want to provide a rigged deck, wherease in a normal game

--- a/src/logic/deck.rs
+++ b/src/logic/deck.rs
@@ -1,0 +1,86 @@
+
+/// trait to define behaviour that you would expect out of a deck of cards
+/// in unit tests, we may want to provide a rigged deck, wherease in a normal game
+/// we just want a standard random deck of cards
+pub trait Deck: Send + std::fmt::Debug {
+    /// shuffle the deck to randomize (possibly) the output of future cards
+    fn shuffle(&mut self);
+
+    /// give us a single card. Optional, because the deck may be exhausted
+    fn draw_card(&mut self) -> Option<Card>;
+}
+
+#[derive(Debug)]
+pub struct StandardDeck {
+    cards: Vec<Card>,
+    top: usize, // index that we deal the next card from
+}
+
+impl StandardDeck {
+    pub fn new() -> Self {
+        // returns a new unshuffled deck of 52 cards
+        let mut cards = Vec::<Card>::with_capacity(52);
+        for rank in Rank::iter() {
+            for suit in Suit::iter() {
+                cards.push(Card { rank, suit });
+            }
+        }
+        Self { cards, top: 0 }
+    }
+}
+
+impl Deck for StandardDeck {
+    fn shuffle(&mut self) {
+        // shuffle the deck of cards
+        self.cards.shuffle(&mut rand::thread_rng());
+        self.top = 0;
+    }
+
+    fn draw_card(&mut self) -> Option<Card> {
+        // take the top card from the deck and move the index of the top of the deck
+        if self.top == self.cards.len() {
+            // the deck is exhausted, no card to give
+            None
+        } else {
+            let card = self.cards[self.top];
+            self.top += 1;
+            Some(card)
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct RiggedDeck {
+    cards: Vec<Card>,
+    top: usize, // index that we deal the next card from
+}
+
+impl RiggedDeck {
+    pub fn new() -> Self {
+        let cards = Vec::<Card>::new();
+        Self { cards, top: 0 }
+    }
+
+    /// push a card into the deck.
+    /// we can set the order exactly how we want
+    pub fn push(&mut self, card: Card) {
+        self.cards.push(card);
+    }
+}
+
+impl Deck for RiggedDeck {
+    /// shuffle does nothing
+    fn shuffle(&mut self) {}
+
+    fn draw_card(&mut self) -> Option<Card> {
+        // take the top card from the deck and move the index of the top of the deck
+        if self.top == self.cards.len() {
+            // the deck is exhausted, no card to give
+            None
+        } else {
+            let card = self.cards[self.top];
+            self.top += 1;
+            Some(card)
+        }
+    }
+}

--- a/src/logic/game.rs
+++ b/src/logic/game.rs
@@ -5,6 +5,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Mutex;
 
 use super::card::{Card, Deck, HandResult, StandardDeck};
+use super::pots::{PotManager};
 use super::player::{Player, PlayerAction, PlayerConfig};
 use crate::hub::GameHub;
 
@@ -36,161 +37,7 @@ impl fmt::Display for Street {
         write!(f, "{}", output)
     }
 }
-
 			
-/// A pot keeps track of the total money, and which player (indices) contributed
-/// A game hand can have multiple pots, when players go all-in, and betting continues
-#[derive(Debug)]
-struct Pot {
-    money: u32,                        // total amount in this pot
-    contributions: HashMap<Uuid, u32>, // which players have contributed to the pot, and how much
-    // the most that any one player can put in. If a player goes all-in into a pot,
-    // then the cap is the amount that player has put in
-    cap: Option<u32>,
-}
-
-impl Pot {
-    fn new() -> Self {
-        Self {
-            money: 0,
-            contributions: HashMap::new(),
-            cap: None,
-        }
-    }
-}
-
-/// The pot manager keeps track of how many pots there are and which players
-/// how contributed how much to each.
-#[derive(Debug)]
-struct PotManager {
-    pots: Vec<Pot>,
-}
-
-impl PotManager {
-    fn new() -> Self {
-        // the pot manager starts with a single main pot
-        Self {
-            pots: vec![Pot::new()],
-        }
-    }
-
-    /// returns a vec of each pot.money for the all pots
-    /// useful to pass to the front end
-    fn simple_repr(&self) -> Vec<u32> {
-        self.pots.iter().map(|x| x.money).collect()
-    }
-
-    /// given a player id and an amount they need to contribute to the pot
-    /// and whether this is putting them all-in), this method puts the proper
-    /// amount into the proper pot(s), and possibly create and redistribute into a new side pot
-    fn contribute(&mut self, player_id: Uuid, amount: u32, all_in: bool) {
-        println!(
-            "inside contribute: {:?}, {:?}, all_in={:?}",
-            player_id, amount, all_in
-        );
-        let mut to_contribute = amount;
-        // insert_pot keeps track of the index at which we want to insert a pot (index+1) to,
-        // and the new cap for the pot at that index
-        let mut insert_pot: Option<(usize, u32)> = None;
-        for (i, pot) in self.pots.iter_mut().enumerate() {
-            let so_far = pot.contributions.entry(player_id).or_insert(0);
-            if let Some(cap) = pot.cap {
-                println!("cap of {}", cap);
-                if *so_far > cap {
-                    panic!(
-                        "somehow player {} put in more than the cap for \
-				    the the pot at index {}",
-                        player_id, i
-                    );
-                } else if *so_far == cap {
-                    println!("we have already filled up this pot");
-                    continue;
-                }
-                // else, we need to put more into the pot
-                let remaining = cap - *so_far; // amount left before the cap
-                if remaining >= to_contribute {
-                    println!(
-                        "the new contribution fits since {} > {}",
-                        remaining, to_contribute
-                    );
-                    *so_far += to_contribute;
-                    pot.money += to_contribute;
-                    if all_in {
-                        // our all-in is smaller than the previous all-in
-                        println!("our all-in is smaller than the previous all-in");
-                        //pot.cap = Some(pot.contributions[&player_id]);
-                        insert_pot = Some((i, pot.contributions[&player_id]));
-                    }
-                    break;
-                } else {
-                    // we need to contribute to the cap, then put more in the next pot
-                    println!("we need to contribute to the cap, then put more in the next pot");
-                    *so_far += remaining;
-                    pot.money += remaining;
-                    assert!(*so_far == cap);
-                    to_contribute -= remaining;
-                    println!("still need to contribute {}", to_contribute)
-                }
-            } else {
-                // there is not cap on this pot, so simply put the new money in for this player
-                println!("no cap");
-                *so_far += to_contribute;
-                pot.money += to_contribute;
-                if all_in {
-                    //pot.cap = Some(pot.contributions[&player_id]);
-                    insert_pot = Some((i, pot.contributions[&player_id]));
-                }
-                break;
-            }
-        }
-        if let Some((index, new_cap)) = insert_pot {
-            println!(
-                "inserting a pot at index {} and capping the previous pot at {}",
-                index + 1,
-                new_cap
-            );
-            self.pots.insert(index + 1, Pot::new());
-            self.transfer_excess(index, new_cap)
-        }
-    }
-
-    /// give the index of a newly-capped pot, we move any excess contributions from the pot
-    /// to the next one in the vecdeque. We also move the existing cap-differential into the pot at index+1
-    /// and set the new_cap in the pot at index.
-    /// This happens when a all-in happens and makes the pot at index newly-capped
-    /// Note: if none of the contributions to the previous pot were higher than the new cap, then no money
-    /// will need to be transfered into the new pot at index+1
-    fn transfer_excess(&mut self, index: usize, new_cap: u32) {
-        let prev_pot = self.pots.get_mut(index).unwrap();
-        println!("prev_pot = {:?}", prev_pot);
-        let mut transfers = HashMap::<Uuid, u32>::new();
-        let prev_cap_opt = prev_pot.cap; // move the previous cap to the new pot (if needed)
-        prev_pot.cap = Some(new_cap);
-        for (id, amount) in prev_pot.contributions.iter_mut() {
-            //let b: bool = id;
-            if *amount > new_cap {
-                // we need to move the excess above the cap of the pot to the new pot
-                let excess = *amount - new_cap;
-                transfers.insert(*id, excess);
-                *amount = new_cap;
-                prev_pot.money -= excess;
-            }
-        }
-        println!("after taking = {:?}", prev_pot);
-        println!("transfers = {:?}", transfers);
-        let mut new_pot = self.pots.get_mut(index + 1).unwrap();
-        new_pot.money = transfers.values().sum();
-        new_pot.contributions = transfers;
-
-        if let Some(prev_cap) = prev_cap_opt {
-            // if the old pot had a cap already, then the new pot is capped at the difference.
-            // e.g. if someone was all-in with 750, then someone calls to go all-in with 500,
-            // the the prev_pot is NOW capped at 500, and the next pot is capped at 250
-            new_pot.cap = Some(prev_cap - new_cap);
-        }
-    }
-}
-
 #[derive(Debug)]
 struct GameHand {
     street: Street,
@@ -1140,56 +987,6 @@ impl Game {
             }
         }
         pay_outs
-    }
-
-    /// Given a player, we need to determine which 5 cards make the best hand for this player
-    fn determine_best_hand(&self, player: &Player, gamehand: &mut GameHand) -> Option<HandResult> {
-        if !player.is_active {
-            // if the player isn't active, then can't have a best hand
-            return None;
-        }
-
-        if let Street::ShowDown = gamehand.street {
-            // we look at all possible 7 choose 5 (21) hands from the hole cards, flop, turn, river
-            let mut best_result: Option<HandResult> = None;
-            let mut hand_count = 0;
-            for exclude_idx1 in 0..7 {
-                //println!("exclude 1 = {}", exclude_idx1);
-                for exclude_idx2 in exclude_idx1 + 1..7 {
-                    //println!("exclude 2 = {}", exclude_idx2);
-                    let mut possible_hand = Vec::with_capacity(5);
-                    hand_count += 1;
-                    for (idx, card) in player
-                        .hole_cards
-                        .iter()
-                        .chain(gamehand.flop.as_ref().unwrap().iter())
-                        .chain(iter::once(&gamehand.turn.unwrap()))
-                        .chain(iter::once(&gamehand.river.unwrap()))
-                        .enumerate()
-                    {
-                        if idx != exclude_idx1 && idx != exclude_idx2 {
-                            //println!("pushing!");
-                            possible_hand.push(*card);
-                        }
-                    }
-                    // we have built a hand of five cards, now evaluate it
-                    let current_result = HandResult::analyze_hand(possible_hand);
-                    match best_result {
-                        None => best_result = Some(current_result),
-                        Some(result) if current_result > result => {
-                            best_result = Some(current_result)
-                        }
-                        _ => (),
-                    }
-                }
-            }
-            assert!(hand_count == 21); // 7 choose 5
-            println!("player = {:?}", player.id);
-            println!("best result = {:?}", best_result);
-            best_result
-        } else {
-            None
-        }
     }
 
     fn play_one_hand(

--- a/src/logic/game_hand.rs
+++ b/src/logic/game_hand.rs
@@ -1,0 +1,200 @@
+use std::fmt;
+use std::collections::{HashMap, HashSet};
+
+use super::card::{Card, HandResult};
+use super::player::{Player, PlayerConfig};
+use super::pots::PotManager;
+
+use json::object;
+use uuid::Uuid;
+
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+pub enum Street {
+    Preflop,
+    Flop,
+    Turn,
+    River,
+    ShowDown,
+}
+
+impl fmt::Display for Street {
+    // This trait requires `fmt` with this exact signature.
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+	let output = match self {
+	    Street::Preflop => "preflop".to_owned(),
+	    Street::Flop => "flop".to_owned(),
+	    Street::Turn => "turn".to_owned(),
+	    Street::River => "river".to_owned(),
+	    Street::ShowDown => "showdown".to_owned(),
+	};
+        write!(f, "{}", output)
+    }
+}
+			
+#[derive(Debug)]
+pub struct GameHand {
+    pub street: Street,
+    pot_manager: PotManager,
+    pub street_contributions: HashMap<Street, [u32; 9]>, // how much a player contributed to the pot during each street
+    pub current_bet: u32, // the current street bet at any moment
+    pub flop: Option<Vec<Card>>,
+    pub turn: Option<Card>,
+    pub river: Option<Card>,
+    pub index_to_act: Option<usize>,
+}
+
+impl GameHand {
+    pub fn default() -> Self {
+        GameHand {
+            street: Street::Preflop,
+            pot_manager: PotManager::new(),
+            street_contributions: HashMap::new(),
+	    current_bet: 0,
+            flop: None,
+            turn: None,
+            river: None,
+	    index_to_act: None,
+        }
+    }
+
+    pub fn pot_repr(&self) -> Vec<u32> {
+	self.pot_manager.simple_repr()
+    }
+    
+    pub fn is_showdown(&self) -> bool {
+	Street::ShowDown == self.street
+    }
+
+    pub fn contribute(&mut self, index: usize, player_id: Uuid, amount: u32, all_in: bool) {
+	let current_contributions = self.street_contributions.get_mut(&self.street).unwrap();	
+        current_contributions[index] += amount;	
+        self.pot_manager.contribute(player_id, amount, all_in);	    
+    }
+	
+    /// The hand is over, so give all money within each pot to the player who deserves it
+    /// If we did not get to show down, then there is one active player who deserves all the money.
+    /// Otherwise, we need to figure out who has the best hand.
+    /// Each pot needs its own calculation
+    pub fn divvy_pots(&self,
+		  players: &mut [Option<Player>; 9],
+		  player_ids_to_configs: &HashMap::<Uuid, PlayerConfig>)
+    -> Vec<json::JsonValue> {
+        let hand_results: HashMap<Uuid, Option<HandResult>> = players
+            .iter()
+            .flatten()
+            .filter(|player| player_ids_to_configs.contains_key(&player.id)) // make sure still in the game
+            .map(|player| (player.id, player.determine_best_hand(self)))
+            .collect();
+        let is_showdown = self.is_showdown();
+        let mut pay_outs: Vec<json::JsonValue> = vec![];	
+        println!("hand results = {:?}", hand_results);
+        if is_showdown {
+            // if we made it to show down, there are multiple players left, so we need to see who
+            // has the best hand.
+            println!("Multiple active players made it to showdown!");
+            println!("{:?}", self.pot_manager);
+            for pot in self.pot_manager.iter() {
+                // for each pot, we determine who should get paid out
+                // a player can only get paid for a pot that they contributed to
+                // so each pot has its own best_hand calculation
+                println!("Looking at pot {:?}", pot);
+                let mut best_ids = HashSet::<Uuid>::new();
+                let mut best_hand: Option<&HandResult> = None;
+                for (id, current_opt) in hand_results
+		    .iter()
+		    .filter(|(id, opt)| pot.is_elligible(&id) && opt.is_some()) {
+                    let current_result = current_opt.as_ref().unwrap();
+                    if best_hand.is_none() || current_result > best_hand.unwrap() {
+                        println!("new best hand for id {:?}", id);
+                        best_hand = Some(current_result);
+                        best_ids.clear();
+                        best_ids.insert(*id); // only one best hand now
+                    } else if current_result == best_hand.unwrap() {
+                        println!("equally good hand for id {:?}", id);
+                        best_ids.insert(*id); // another index that also has the best hand
+                    } else {
+                        println!("hand worse for id {:?}", id);
+                        continue;
+                    }
+                }
+                // divy the pot to all the winners
+                let num_winners = best_ids.len();
+                let amount = (pot.get_money() as f64 / num_winners as f64) as u32;
+                //self.pot_manager.pots.first_mut().unwrap().money = 0;
+                GameHand::pay_players(&mut pay_outs, players, player_ids_to_configs, best_ids, amount, best_hand, is_showdown);
+            }
+        } else {
+            // the hand ended before Showdown, so we simple find the one active player remaining
+	    // TODO: is this weird? Is it possible that there could be more than one pot...?
+            let best_ids:  HashSet::<Uuid> = players
+		.iter()
+		.flatten()
+		.filter(|player| player.is_active)
+		.map(|player| player.id).collect();
+            // if we didn't make it to show down, there better be only one player left
+            assert!(best_ids.len() == 1);
+            GameHand::pay_players(
+		&mut pay_outs,
+                players,
+		player_ids_to_configs,
+                best_ids,
+                self.pot_manager.iter().next().unwrap().get_money(),
+                None, // no hand result if not at showdown
+                is_showdown,
+            );
+        }
+	pay_outs
+    }
+
+    /// iterate through the players, and any with an id in best_ids gets thei money increaed by amount
+    /// Moreover, construct a json payout message for each one of these payouts, and add it to the given pay_outs vec
+    fn pay_players(
+	pay_outs: &mut Vec<json::JsonValue>,
+	players: &mut [Option<Player>; 9],
+	player_ids_to_configs: &HashMap::<Uuid, PlayerConfig>,
+        best_ids: HashSet<Uuid>,
+        amount: u32,
+        best_hand: Option<&HandResult>,
+        is_showdown: bool,
+    ) {
+        for (i, player_spot) in players.iter_mut().enumerate() {
+            if player_spot.is_some() {
+                let player = player_spot.as_mut().unwrap();
+                if best_ids.contains(&player.id) {
+                    // get the name for messages
+                    let name: String = if let Some(config) = &player_ids_to_configs.get(&player.id)
+                    {
+                        config.name.as_ref().unwrap().clone()
+                    } else {
+                        // it is a bit weird if we made it all the way to the pay stage for a left player
+                        "Player who left".to_string()
+                    };
+
+                    let mut message = object! {
+                        payout: amount,
+                        index: i,
+                        player_name: name,
+                        is_showdown: is_showdown,
+                    };
+		    
+		    if let Some(hand_result) = best_hand {
+                        message["hand_result"] = hand_result.hand_ranking_string().into();			
+			message["constituent_cards"] = hand_result.constituent_cards_string().into();
+			message["kickers"] = hand_result.kickers_string().into();						
+		    }
+                    println!(
+                        "paying out {:?} to {:?}, with hand result = {:?}",
+                        amount, player.id, best_hand
+                    );
+		    if is_showdown {
+			let hole_string = format!("{}{}", player.hole_cards[0], player.hole_cards[1]);
+                        message["hole_cards"] = hole_string.into();			
+		    }
+                    pay_outs.push(message);
+                    player.pay(amount);
+                }
+            }
+        }
+    }
+    
+}

--- a/src/logic/mod.rs
+++ b/src/logic/mod.rs
@@ -3,6 +3,7 @@ mod pots;
 
 pub mod game;
 pub mod player;
+pub mod deck;
 
 pub use game::Game;
 pub use player::PlayerAction;

--- a/src/logic/mod.rs
+++ b/src/logic/mod.rs
@@ -1,4 +1,6 @@
 mod card;
+mod pots;
+
 pub mod game;
 pub mod player;
 

--- a/src/logic/mod.rs
+++ b/src/logic/mod.rs
@@ -1,9 +1,10 @@
 mod card;
 mod pots;
+mod game_hand;
 
-pub mod game;
 pub mod player;
 pub mod deck;
+pub mod game;
 
 pub use game::Game;
 pub use player::PlayerAction;

--- a/src/logic/player.rs
+++ b/src/logic/player.rs
@@ -1,7 +1,9 @@
-use super::card::Card;
+use super::card::{Card, HandResult};
+use super::game::{GameHand};
 use crate::messages::WsMessage;
 use actix::prelude::Recipient;
 use std::collections::HashMap;
+use std::iter;
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 use std::fmt;
@@ -170,4 +172,53 @@ impl Player {
     pub fn is_all_in(&self) -> bool {
         self.is_active && self.money == 0
     }
+
+    /// Given a gamehand (usually with a full run-out to the river),
+    /// we need to determine which 5 cards make the best hand for this player
+    /// If the player is not active, or if the hand never made it to showdown, then we simply
+    /// return None as the optional best hand.
+    pub fn determine_best_hand(&self, gamehand: &GameHand) -> Option<HandResult> {
+        if !self.is_active {
+            // if the player isn't active, then can't have a best hand
+            return None;
+        }
+	if !gamehand.is_showdown() {
+	    // there is no "best hand" if we didn't even make it to showdown
+	    return None;
+	}
+	// we look at all possible 7 choose 5 (21) hands from the hole cards, flop, turn, river
+	let mut best_result: Option<HandResult> = None;
+	let mut hand_count = 0;
+	for exclude_idx1 in 0..7 {
+	    for exclude_idx2 in exclude_idx1 + 1..7 {
+		let mut possible_hand = Vec::with_capacity(5);
+		hand_count += 1;
+		for (idx, card) in self
+		    .hole_cards
+		    .iter()
+		    .chain(gamehand.flop.as_ref().unwrap().iter())
+		    .chain(iter::once(&gamehand.turn.unwrap()))
+		    .chain(iter::once(&gamehand.river.unwrap()))
+		    .enumerate()
+		{
+		    if idx != exclude_idx1 && idx != exclude_idx2 {
+			//println!("pushing!");
+			possible_hand.push(*card);
+		    }
+		}
+		// we have built a hand of five cards, now evaluate it
+		let current_result = HandResult::analyze_hand(possible_hand);
+		match best_result {
+		    None => best_result = Some(current_result),
+		    Some(result) if current_result > result => {
+			best_result = Some(current_result)
+		    }
+		    _ => (),
+		}
+	    }
+	}
+	assert!(hand_count == 21); // 7 choose 5
+	best_result
+    }
+    
 }

--- a/src/logic/player.rs
+++ b/src/logic/player.rs
@@ -1,5 +1,5 @@
 use super::card::{Card, HandResult};
-use super::game::{GameHand};
+use super::game_hand::GameHand;
 use crate::messages::WsMessage;
 use actix::prelude::Recipient;
 use std::collections::HashMap;

--- a/src/logic/pots.rs
+++ b/src/logic/pots.rs
@@ -1,0 +1,155 @@
+use std::collections::HashMap;
+use uuid::Uuid;
+
+/// A pot keeps track of the total money, and which player (indices) contributed
+/// A game hand can have multiple pots, when players go all-in, and betting continues
+#[derive(Debug)]
+struct Pot {
+    money: u32,                        // total amount in this pot
+    contributions: HashMap<Uuid, u32>, // which players have contributed to the pot, and how much
+    // the most that any one player can put in. If a player goes all-in into a pot,
+    // then the cap is the amount that player has put in
+    cap: Option<u32>,
+}
+
+impl Pot {
+    fn new() -> Self {
+        Self {
+            money: 0,
+            contributions: HashMap::new(),
+            cap: None,
+        }
+    }
+}
+
+/// The pot manager keeps track of how many pots there are and which players
+/// how contributed how much to each.
+#[derive(Debug)]
+pub struct PotManager {
+    pots: Vec<Pot>,
+}
+
+impl PotManager {
+    pub fn new() -> Self {
+        // the pot manager starts with a single main pot
+        Self {
+            pots: vec![Pot::new()],
+        }
+    }
+
+    /// returns a vec of each pot.money for the all pots
+    /// useful to pass to the front end
+    pub fn simple_repr(&self) -> Vec<u32> {
+        self.pots.iter().map(|x| x.money).collect()
+    }
+
+    /// given a player id and an amount they need to contribute to the pot
+    /// and whether this is putting them all-in), this method puts the proper
+    /// amount into the proper pot(s), and possibly create and redistribute into a new side pot
+    pub fn contribute(&mut self, player_id: Uuid, amount: u32, all_in: bool) {
+        println!(
+            "inside contribute: {:?}, {:?}, all_in={:?}",
+            player_id, amount, all_in
+        );
+        let mut to_contribute = amount;
+        // insert_pot keeps track of the index at which we want to insert a pot (index+1) to,
+        // and the new cap for the pot at that index
+        let mut insert_pot: Option<(usize, u32)> = None;
+        for (i, pot) in self.pots.iter_mut().enumerate() {
+            let so_far = pot.contributions.entry(player_id).or_insert(0);
+            if let Some(cap) = pot.cap {
+                println!("cap of {}", cap);
+                if *so_far > cap {
+                    panic!(
+                        "somehow player {} put in more than the cap for \
+				    the the pot at index {}",
+                        player_id, i
+                    );
+                } else if *so_far == cap {
+                    println!("we have already filled up this pot");
+                    continue;
+                }
+                // else, we need to put more into the pot
+                let remaining = cap - *so_far; // amount left before the cap
+                if remaining >= to_contribute {
+                    println!(
+                        "the new contribution fits since {} > {}",
+                        remaining, to_contribute
+                    );
+                    *so_far += to_contribute;
+                    pot.money += to_contribute;
+                    if all_in {
+                        // our all-in is smaller than the previous all-in
+                        println!("our all-in is smaller than the previous all-in");
+                        //pot.cap = Some(pot.contributions[&player_id]);
+                        insert_pot = Some((i, pot.contributions[&player_id]));
+                    }
+                    break;
+                } else {
+                    // we need to contribute to the cap, then put more in the next pot
+                    println!("we need to contribute to the cap, then put more in the next pot");
+                    *so_far += remaining;
+                    pot.money += remaining;
+                    assert!(*so_far == cap);
+                    to_contribute -= remaining;
+                    println!("still need to contribute {}", to_contribute)
+                }
+            } else {
+                // there is not cap on this pot, so simply put the new money in for this player
+                println!("no cap");
+                *so_far += to_contribute;
+                pot.money += to_contribute;
+                if all_in {
+                    //pot.cap = Some(pot.contributions[&player_id]);
+                    insert_pot = Some((i, pot.contributions[&player_id]));
+                }
+                break;
+            }
+        }
+        if let Some((index, new_cap)) = insert_pot {
+            println!(
+                "inserting a pot at index {} and capping the previous pot at {}",
+                index + 1,
+                new_cap
+            );
+            self.pots.insert(index + 1, Pot::new());
+            self.transfer_excess(index, new_cap)
+        }
+    }
+
+    /// give the index of a newly-capped pot, we move any excess contributions from the pot
+    /// to the next one in the vecdeque. We also move the existing cap-differential into the pot at index+1
+    /// and set the new_cap in the pot at index.
+    /// This happens when a all-in happens and makes the pot at index newly-capped
+    /// Note: if none of the contributions to the previous pot were higher than the new cap, then no money
+    /// will need to be transfered into the new pot at index+1
+    fn transfer_excess(&mut self, index: usize, new_cap: u32) {
+        let prev_pot = self.pots.get_mut(index).unwrap();
+        println!("prev_pot = {:?}", prev_pot);
+        let mut transfers = HashMap::<Uuid, u32>::new();
+        let prev_cap_opt = prev_pot.cap; // move the previous cap to the new pot (if needed)
+        prev_pot.cap = Some(new_cap);
+        for (id, amount) in prev_pot.contributions.iter_mut() {
+            //let b: bool = id;
+            if *amount > new_cap {
+                // we need to move the excess above the cap of the pot to the new pot
+                let excess = *amount - new_cap;
+                transfers.insert(*id, excess);
+                *amount = new_cap;
+                prev_pot.money -= excess;
+            }
+        }
+        println!("after taking = {:?}", prev_pot);
+        println!("transfers = {:?}", transfers);
+        let mut new_pot = self.pots.get_mut(index + 1).unwrap();
+        new_pot.money = transfers.values().sum();
+        new_pot.contributions = transfers;
+
+        if let Some(prev_cap) = prev_cap_opt {
+            // if the old pot had a cap already, then the new pot is capped at the difference.
+            // e.g. if someone was all-in with 750, then someone calls to go all-in with 500,
+            // the the prev_pot is NOW capped at 500, and the next pot is capped at 250
+            new_pot.cap = Some(prev_cap - new_cap);
+        }
+    }
+}

--- a/src/logic/pots.rs
+++ b/src/logic/pots.rs
@@ -1,10 +1,12 @@
 use std::collections::HashMap;
+use std::ops::Deref;
+
 use uuid::Uuid;
 
 /// A pot keeps track of the total money, and which player (indices) contributed
 /// A game hand can have multiple pots, when players go all-in, and betting continues
 #[derive(Debug)]
-struct Pot {
+pub struct Pot {
     money: u32,                        // total amount in this pot
     contributions: HashMap<Uuid, u32>, // which players have contributed to the pot, and how much
     // the most that any one player can put in. If a player goes all-in into a pot,
@@ -20,6 +22,17 @@ impl Pot {
             cap: None,
         }
     }
+
+    /// a public getter, since we don't want people outside the pot manager to be chaning the field
+    pub fn get_money(&self) -> u32 {
+	self.money
+    }
+    
+    /// is the given player id elligible to win the pot?
+    /// i.e. have they contributed to it
+    pub fn is_elligible(&self, id: &Uuid) -> bool {
+	self.contributions.contains_key(id)
+    }
 }
 
 /// The pot manager keeps track of how many pots there are and which players
@@ -29,6 +42,14 @@ pub struct PotManager {
     pots: Vec<Pot>,
 }
 
+/// this lets us call .iter() right on the PotManager itself to get access to self.pots
+impl Deref for PotManager {
+    type Target = Vec<Pot>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.pots
+    }
+}
 impl PotManager {
     pub fn new() -> Self {
         // the pot manager starts with a single main pot
@@ -151,5 +172,6 @@ impl PotManager {
             // the the prev_pot is NOW capped at 500, and the next pot is capped at 250
             new_pot.cap = Some(prev_cap - new_cap);
         }
-    }
+    }    
+    
 }

--- a/src/logic/pots.rs
+++ b/src/logic/pots.rs
@@ -61,7 +61,7 @@ impl PotManager {
     /// returns a vec of each pot.money for the all pots
     /// useful to pass to the front end
     pub fn simple_repr(&self) -> Vec<u32> {
-        self.pots.iter().map(|x| x.money).collect()
+        self.pots.iter().filter(|x| x.money > 0).map(|x| x.money).collect()
     }
 
     /// given a player id and an amount they need to contribute to the pot

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ async fn main() -> std::io::Result<()> {
     let app_state = Arc::new(AtomicUsize::new(0));
 
     // start main hub actor
-    let hub = hub::GameHub::new(app_state.clone()).start();
+    let hub = hub::GameHub::new().start();
 
     log::info!("starting HTTP server at http://{}:{}", args.ip, args.port);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,11 +19,13 @@ mod hub;
 mod messages;
 mod session;
 
+const LOCAL_HOST: &str = "localhost";
+
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
     /// ip address
-    #[arg(short, long, default_value_t = ("localhost".to_string()))]
+    #[arg(short, long, default_value_t = LOCAL_HOST.to_string())]
     ip: String,
 
     /// port


### PR DESCRIPTION
- split out a bunch of code from game.rs
- now files for decks, pots, and game_hand gets its own file, with each file taking more responsibility that should belong to them.
- there might be more cleaning up to be had with more logic moving into gamehand from game itself, but this is  a nice start.

- moreover, there was a bug in the payouts message going to the front end, where each pot would override the payouts field from previous pots. Fixed this.