### PR TITLE
Showdown cards

### DIFF
--- a/react-ui/src/App.js
+++ b/react-ui/src/App.js
@@ -132,8 +132,8 @@ class App extends React.Component {
           that.handleTableList(json.tables);
         } else if (json.msg_type === "table_info") {
           that.updateTableInfo(json);
-        } else if (json.msg_type === "created_game") {
-          let output = "You created a game. Type '/help' for a list of available admin commands. (Private games only)";
+        } else if (json.msg_type === "created_table") {
+          let output = "You created a table. Type '/help' for a list of available admin commands. (Private games only)";
           that.chat("Dealer", output);	
           that.setState({creatingTable: false});
           that.props.navigate("/table");

--- a/react-ui/src/App.js
+++ b/react-ui/src/App.js
@@ -160,15 +160,15 @@ class App extends React.Component {
             that.chat("Dealer", `Your turn to act. There is currently no bet.`);
           }
         } else if (json.msg_type === "finish_hand") {
-          that.saveHandHistory(json.pay_outs);
+          that.saveHandHistory(json.settlements);
 
-          for (let payOut of json.pay_outs) {
+          for (let settlement of json.settlements) {
             let showdown = "";
-            if (payOut.is_showdown) {
-              showdown = ` in a showdown with ${payOut.hand_result}: ${payOut.constituent_cards} and ${payOut.kickers} kicker.`;
+            if (settlement.is_showdown) {
+              showdown = ` in a showdown with ${settlement.hand_result}: ${settlement.constituent_cards} and ${settlement.kickers} kicker.`;
             }
 
-            that.chat("Dealer", `${payOut.player_name} won ${payOut.payout}${showdown}`);
+            that.chat("Dealer", `${settlement.player_name} won ${settlement.payout}${showdown}`);
           }
         } else if (json.msg_type === "left_game") {
           that.props.navigate("/menu");

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -1,6 +1,6 @@
-//! `GameHub` is an actor. It keeps track of the current tables/games
+//! `TableHub` is an actor. It keeps track of the current tables/games
 //! and manages PlayerConfig structs (which include Ws Recipients)
-//! When a WsMessage comes in from a WsGameSession, the GameHub routes the message to the proper Game
+//! When a WsMessage comes in from a WsGameSession, the TableHub routes the message to the proper Game
 
 //! This file is adapted from the actix-web chat websocket example
 
@@ -27,7 +27,7 @@ const GAME_NAME_LEN: usize = 4;
 
 /// `Gamelobby` manages chat tables and responsible for coordinating chat session.
 #[derive(Debug)]
-pub struct GameHub {
+pub struct TableHub {
     // map from session id to the PlayerConfig for players that have connected but are not at a table
     main_lobby_connections: HashMap<Uuid, PlayerConfig>,
 
@@ -44,9 +44,9 @@ pub struct GameHub {
     //visitor_count: Arc<AtomicUsize>,
 }
 
-impl GameHub {
-    pub fn new() -> GameHub {
-        GameHub {
+impl TableHub {
+    pub fn new() -> TableHub {
+        TableHub {
             main_lobby_connections: HashMap::new(),
             players_to_table: HashMap::new(),
             tables_to_actions: HashMap::new(),
@@ -56,8 +56,8 @@ impl GameHub {
     }    
 }
 
-/// Make actor from `GameHub`
-impl Actor for GameHub {
+/// Make actor from `TableHub`
+impl Actor for TableHub {
     /// We are going to use simple Context, we just need ability to communicate
     /// with other actors.
     type Context = Context<Self>;
@@ -78,7 +78,7 @@ impl Actor for GameHub {
 /// Handler for Connect message.
 ///
 /// Register new session with a given uuid.It could be brand new or a reconnection of an existing uuid
-impl Handler<Connect> for GameHub {
+impl Handler<Connect> for TableHub {
     type Result = MessageResult<Connect>; // use MessageResult so that we can return a Uuid
 
     fn handle(&mut self, msg: Connect, _: &mut Context<Self>) -> Self::Result {
@@ -142,7 +142,7 @@ impl Handler<Connect> for GameHub {
 }
 
 /// Handler for `ListTables` message.
-impl Handler<ListTables> for GameHub {
+impl Handler<ListTables> for TableHub {
     type Result = MessageResult<ListTables>;
 
     /// we return a vec of table names of public tables now and also
@@ -164,7 +164,7 @@ impl Handler<ListTables> for GameHub {
 }
 
 /// Handler for PlayerName message.
-impl Handler<PlayerName> for GameHub {
+impl Handler<PlayerName> for TableHub {
     type Result = ();
 
     fn handle(&mut self, msg: PlayerName, _: &mut Context<Self>) {
@@ -203,7 +203,7 @@ impl Handler<PlayerName> for GameHub {
 
 /// Join table, send disconnect message to old table
 /// send join message to new table
-impl Handler<Join> for GameHub {
+impl Handler<Join> for TableHub {
     type Result = ();
 
     fn handle(&mut self, msg: Join, _: &mut Context<Self>) {
@@ -273,7 +273,7 @@ impl Handler<Join> for GameHub {
 
 /// Handler for a player that has been returned from a game officially
 /// This message comes FROM a game and provides the config, which we can put back in the lobby`
-impl Handler<Returned> for GameHub {
+impl Handler<Returned> for TableHub {
     type Result = ();
 
     fn handle(&mut self, msg: Returned, _: &mut Context<Self>) {
@@ -312,7 +312,7 @@ impl Handler<Returned> for GameHub {
 }
 
 /// create table, cannot already be at a table
-impl Handler<Create> for GameHub {
+impl Handler<Create> for TableHub {
     type Result = Result<String, CreateGameError>;
 
     /// creates a game and returns either Ok(table_name) or an Er(CreateGameError)
@@ -445,7 +445,7 @@ impl Handler<Create> for GameHub {
 }
 
 /// Handler for Message message.
-impl Handler<PlayerActionMessage> for GameHub {
+impl Handler<PlayerActionMessage> for TableHub {
     type Result = ();
 
     /// the player has sent a message of what their next action in the game should be,
@@ -471,7 +471,7 @@ impl Handler<PlayerActionMessage> for GameHub {
 
 /// the game tells us that it has ended (no more human players),
 /// so lets remove it from our hub records
-impl Handler<GameOver> for GameHub {
+impl Handler<GameOver> for TableHub {
     type Result = ();
 
     fn handle(&mut self, msg: GameOver, _: &mut Context<Self>) {
@@ -495,7 +495,7 @@ impl Handler<GameOver> for GameHub {
 /// Handler for MetaAction messages.
 /// The types of meta actions inside a MetaAction message should simply be
 /// passed on to the game (if one exists)
-impl Handler<MetaActionMessage> for GameHub {
+impl Handler<MetaActionMessage> for TableHub {
     type Result = ();
 
     fn handle(&mut self, msg: MetaActionMessage, _: &mut Context<Self>) {

--- a/src/logic/game_hand.rs
+++ b/src/logic/game_hand.rs
@@ -92,7 +92,7 @@ impl GameHand {
 	    // for each pot, we determine who should get paid out
 	    // a player can only get paid for a pot that they contributed to
 	    // so each pot has its own best_hand calculation
-            if is_showdown {
+            let (best_ids, best_hand, amount) = if is_showdown {
 		// if we made it to show down, there are multiple players left, so we need to see who
 		// has the best hand.
 		println!("Multiple active players made it to showdown!");
@@ -119,10 +119,9 @@ impl GameHand {
 		// divy the pot to all the winners
 		let num_winners = best_ids.len();
 		let amount = (pot.get_money() as f64 / num_winners as f64) as u32;
-		GameHand::pay_players(&mut pay_outs, players, player_ids_to_configs,
-				      best_ids, amount, best_hand, is_showdown);
+		(best_ids, best_hand, amount)
             } else {
-            // the hand ended before Showdown, so we simple find the one active player remaining
+		// the hand ended before Showdown, so we simple find the one active player remaining
 		let best_ids:  HashSet::<Uuid> = players
 		    .iter()
 		    .flatten()
@@ -130,16 +129,13 @@ impl GameHand {
 		    .map(|player| player.id).collect();
 		// if we didn't make it to show down, there better be only one player left
 		assert!(best_ids.len() == 1);
-		GameHand::pay_players(
-		    &mut pay_outs,
-                    players,
-		    player_ids_to_configs,
-                    best_ids,
-                    self.pot_manager.iter().next().unwrap().get_money(),
-                    None, // no hand result if not at showdown
-                    is_showdown,
-		);
-            }
+		let best_hand = None;
+		let amount = self.pot_manager.iter().next().unwrap().get_money();
+		(best_ids, best_hand, amount)
+            };
+	    GameHand::pay_players(&mut pay_outs, players, player_ids_to_configs,
+				  best_ids, amount, best_hand, is_showdown);
+	    
 	}
 	pay_outs
     }

--- a/src/logic/game_hand.rs
+++ b/src/logic/game_hand.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::collections::{HashMap, HashSet};
 
 use super::card::{Card, HandResult};
-use super::player::{Player, PlayerConfig};
+use super::player::{Player, PlayerConfig, PlayerAction};
 use super::pots::PotManager;
 
 use json::object;
@@ -75,9 +75,15 @@ impl GameHand {
     /// If we did not get to show down, then there is one active player who deserves all the money.
     /// Otherwise, we need to figure out who has the best hand.
     /// Each pot needs its own calculation
-    pub fn divvy_pots(&self,
-		  players: &mut [Option<Player>; 9],
-		  player_ids_to_configs: &HashMap::<Uuid, PlayerConfig>)
+    /// Returns a list of settlements of the paid (or active at showdown) players.
+    /// A settlement shows the payout and hole cards of winning players, OR possibly the hole cards
+    /// of losing players (if they had to show in the final reveal order of cards - starting with most aggression)
+    pub fn divvy_pots(
+	&self,
+	players: &mut [Option<Player>; 9],
+	player_ids_to_configs: &HashMap::<Uuid, PlayerConfig>,
+	starting_idx: usize
+    )
     -> Vec<json::JsonValue> {
         let hand_results: HashMap<Uuid, Option<HandResult>> = players
             .iter()
@@ -85,41 +91,54 @@ impl GameHand {
             .filter(|player| player_ids_to_configs.contains_key(&player.id)) // make sure still in the game
             .map(|player| (player.id, player.determine_best_hand(self)))
             .collect();
+	
         let is_showdown = self.is_showdown();
-        let mut pay_outs: Vec<json::JsonValue> = vec![];	
+        let mut settlements: Vec<json::JsonValue> = vec![];	
         println!("hand results = {:?}", hand_results);
-	for pot in self.pot_manager.iter() {
+	let showdown_starting_idx = GameHand::get_showdown_starting_idx(players, starting_idx);
+	for (pot_idx, pot) in self.pot_manager.iter().enumerate().filter(|(_, pot)| pot.money > 0) {
 	    // for each pot, we determine who should get paid out
 	    // a player can only get paid for a pot that they contributed to
 	    // so each pot has its own best_hand calculation
-            let (best_ids, best_hand, amount) = if is_showdown {
+            let (best_ids, best_hand, amount, showing_ids, elligible_ids) = if is_showdown {
 		// if we made it to show down, there are multiple players left, so we need to see who
 		// has the best hand.
 		println!("Multiple active players made it to showdown!");
 		println!("Looking at pot {:?}", pot);
-		let mut best_ids = HashSet::<Uuid>::new();
+		let mut best_ids = HashSet::<Uuid>::new(); // who is a winner of the pot
+		let mut showing_ids = HashSet::<Uuid>::new(); // who needs to show their cards
+		let mut elligible_ids = HashSet::<Uuid>::new(); // who was even in the pot (and should get a settlement)
 		let mut best_hand: Option<&HandResult> = None;
-		for (id, current_opt) in hand_results
-		    .iter()
-		    .filter(|(id, opt)| pot.is_elligible(&id) && opt.is_some()) {
-			let current_result = current_opt.as_ref().unwrap();
-			if best_hand.is_none() || current_result > best_hand.unwrap() {
-			    println!("new best hand for id {:?}", id);
-			    best_hand = Some(current_result);
-			    best_ids.clear();
-			    best_ids.insert(*id); // only one best hand now
-			} else if current_result == best_hand.unwrap() {
-			    println!("equally good hand for id {:?}", id);
-			    best_ids.insert(*id); // another index that also has the best hand
-			} else {
-			    println!("hand worse for id {:?}", id);
-			    continue;
+		for i in (showdown_starting_idx..9).chain(0..showdown_starting_idx) {
+		    if let Some(player) = &mut players[i]  {
+			if pot.is_elligible(&player.id) && hand_results.get(&player.id).is_some() {
+			    let current_opt = hand_results.get(&player.id).unwrap();
+			    if current_opt.is_none() {
+				continue;
+			    }
+			    elligible_ids.insert(player.id); // indicates we looked at them even for this pot
+			    let current_result = current_opt.as_ref().unwrap();
+			    if best_hand.is_none() || current_result > best_hand.unwrap() {
+				println!("new best hand for id {:?}", player.id);
+				best_hand = Some(&current_result);
+				best_ids.clear();
+				best_ids.insert(player.id); // only one best hand now
+				showing_ids.insert(player.id); // they need to show since a potential winner at this point
+			    } else if current_result == best_hand.unwrap() {
+				println!("equally good hand for id {:?}", player.id);
+				best_ids.insert(player.id); // another index that also has the best hand
+				showing_ids.insert(player.id); // they need to show since a potential winner at this point
+			    } else {
+				println!("hand worse for id {:?}", player.id);
+				continue;
+			    }
 			}
 		    }
+		}
 		// divy the pot to all the winners
 		let num_winners = best_ids.len();
 		let amount = (pot.get_money() as f64 / num_winners as f64) as u32;
-		(best_ids, best_hand, amount)
+		(best_ids, best_hand, amount, showing_ids, elligible_ids)
             } else {
 		// the hand ended before Showdown, so we simple find the one active player remaining
 		let best_ids:  HashSet::<Uuid> = players
@@ -130,65 +149,103 @@ impl GameHand {
 		// if we didn't make it to show down, there better be only one player left
 		assert!(best_ids.len() == 1);
 		let best_hand = None;
-		let amount = self.pot_manager.iter().next().unwrap().get_money();
-		(best_ids, best_hand, amount)
+		    let amount = self.pot_manager.iter().next().unwrap().get_money();
+		let showing_ids = best_ids.clone();
+		let elligible_ids = best_ids.clone();		
+		(best_ids, best_hand, amount, showing_ids, elligible_ids)
             };
-	    GameHand::pay_players(&mut pay_outs, players, player_ids_to_configs,
-				  best_ids, amount, best_hand, is_showdown);
+	    self.settle_players(&mut settlements, players, player_ids_to_configs, &hand_results, pot_idx,
+				     best_ids, best_hand, amount, showing_ids, elligible_ids, showdown_starting_idx);
 	    
 	}
-	pay_outs
+	settlements
     }
 
-    /// iterate through the players, and any with an id in best_ids gets thei money increaed by amount
-    /// Moreover, construct a json payout message for each one of these payouts, and add it to the given pay_outs vec
-    fn pay_players(
-	pay_outs: &mut Vec<json::JsonValue>,
+    /// iterate through the players, and any with an id in best_ids gets their money increased by amount.
+    /// Moreover, construct a json settlement message for each one of these payouts,
+    /// and add it to the given settlements vec (if they need to show)
+    fn settle_players(
+	&self, 
+	settlements: &mut Vec<json::JsonValue>,
 	players: &mut [Option<Player>; 9],
 	player_ids_to_configs: &HashMap::<Uuid, PlayerConfig>,
+	hand_results: &HashMap<Uuid, Option<HandResult>>,	
+	pot_idx: usize,
         best_ids: HashSet<Uuid>,
-        amount: u32,
         best_hand: Option<&HandResult>,
-        is_showdown: bool,
+        amount: u32,
+	showing_ids: HashSet<Uuid>,
+	elligible_ids: HashSet<Uuid>,	
+	showdown_starting_idx: usize,
     ) {
-        for (i, player_spot) in players.iter_mut().enumerate() {
-            if player_spot.is_some() {
-                let player = player_spot.as_mut().unwrap();
-                if best_ids.contains(&player.id) {
-                    // get the name for messages
-                    let name: String = if let Some(config) = &player_ids_to_configs.get(&player.id)
-                    {
-                        config.name.as_ref().unwrap().clone()
-                    } else {
-                        // it is a bit weird if we made it all the way to the pay stage for a left player
-                        "Player who left".to_string()
-                    };
+        let is_showdown = self.is_showdown();
+        for i in (showdown_starting_idx..9).chain(0..showdown_starting_idx) {
+	    if let Some(player) = &mut players[i]  {
+		if !elligible_ids.contains(&player.id) {
+                    continue;
+		}
+		let name: String = if let Some(config) = &player_ids_to_configs.get(&player.id)
+		{
+		    config.name.as_ref().unwrap().clone()
+		} else {
+		    // it is a bit weird if we made it all the way to the pay stage for a left player
+		    "Player who left".to_string()
+		};
 
-                    let mut message = object! {
-                        payout: amount,
-                        index: i,
-                        player_name: name,
-                        is_showdown: is_showdown,
-                    };
-		    
-		    if let Some(hand_result) = best_hand {
-                        message["hand_result"] = hand_result.hand_ranking_string().into();			
+		let mut message = object! {
+		    index: i,
+		    player_name: name,
+		    is_showdown: is_showdown,
+		    pot_index: pot_idx,
+		};
+		
+		if best_ids.contains(&player.id) {
+		    message["winner"] = true.into();		    
+		    message["payout"] = amount.into();
+		    println!(
+			"paying out {:?} to {:?}, with hand result = {:?}",
+			amount, player.id, best_hand
+		    );
+		    player.pay(amount);		    
+		} else {
+		    message["winner"] = false.into();
+		}
+		if is_showdown && showing_ids.contains(&player.id) {		    
+		    let hole_string = format!("{}{}", player.hole_cards[0], player.hole_cards[1]);
+		    message["hole_cards"] = hole_string.into();
+		    if let Some(hand_result) = hand_results.get(&player.id).unwrap() {
+			message["hand_result"] = hand_result.hand_ranking_string().into();			
 			message["constituent_cards"] = hand_result.constituent_cards_string().into();
-			message["kickers"] = hand_result.kickers_string().into();						
+			message["kickers"] = hand_result.kickers_string().into();
 		    }
-                    println!(
-                        "paying out {:?} to {:?}, with hand result = {:?}",
-                        amount, player.id, best_hand
-                    );
-		    if is_showdown {
-			let hole_string = format!("{}{}", player.hole_cards[0], player.hole_cards[1]);
-                        message["hole_cards"] = hole_string.into();			
-		    }
-                    pay_outs.push(message);
-                    player.pay(amount);
-                }
+		    
+		}
+		settlements.push(message);
             }
         }
     }
-    
+
+    // determine where to start the showing of cards
+    // if there is a last-aggressor, then it starts with them,
+    // otherwise, it defaults to the street starting idx    
+    fn get_showdown_starting_idx(
+	players: &mut [Option<Player>; 9],
+	starting_idx: usize,
+    ) -> usize {
+	let mut showdown_starting_idx = starting_idx;
+        for (i, player_spot) in players.iter_mut().enumerate() {
+	    if player_spot.is_some() {
+                let player = player_spot.as_mut().unwrap();
+		if let Some(PlayerAction::Bet(_)) = player.last_action {
+		    // if the player's last action was a bet, then they we the last aggressor,
+		    // and hence has to show first
+		    showdown_starting_idx = i;
+		    break;
+		}
+	    }
+	}
+	showdown_starting_idx
+    }
 }
+
+

--- a/src/logic/mod.rs
+++ b/src/logic/mod.rs
@@ -4,9 +4,9 @@ mod game_hand;
 
 pub mod player;
 pub mod deck;
-pub mod game;
+pub mod table;
 
-pub use game::Game;
+pub use table::Table;
 pub use player::PlayerAction;
 pub use player::PlayerConfig;
 pub use player::PLAYER_TIMEOUT;

--- a/src/logic/player.rs
+++ b/src/logic/player.rs
@@ -117,7 +117,6 @@ impl PlayerConfig {
     /// a player can't sit in a table indefinitely.
     pub fn has_active_heart_beat(&self) -> bool {
 	let gap = Instant::now().duration_since(self.heart_beat);
-	println!("config = {:?}, gap = {:?}", self, gap);
 	if gap > PLAYER_TIMEOUT {
             // heartbeat timed out
             println!("player timed out!");

--- a/src/logic/pots.rs
+++ b/src/logic/pots.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 /// A game hand can have multiple pots, when players go all-in, and betting continues
 #[derive(Debug)]
 pub struct Pot {
-    money: u32,                        // total amount in this pot
+    pub money: u32,                        // total amount in this pot
     contributions: HashMap<Uuid, u32>, // which players have contributed to the pot, and how much
     // the most that any one player can put in. If a player goes all-in into a pot,
     // then the cap is the amount that player has put in

--- a/src/logic/table.rs
+++ b/src/logic/table.rs
@@ -9,9 +9,9 @@ use super::deck::{Deck, StandardDeck};
 use super::game_hand::{GameHand, Street};
 
 use super::player::{Player, PlayerAction, PlayerConfig};
-use crate::hub::GameHub;
+use crate::hub::TableHub;
 
-use crate::messages::{AdminCommand, GameOver, JoinGameError, MetaAction, Returned, ReturnedReason, WsMessage};
+use crate::messages::{AdminCommand, GameOver, JoinTableError, MetaAction, Returned, ReturnedReason, WsMessage};
 
 use std::{cmp, sync::Arc, thread, time};
 
@@ -21,8 +21,8 @@ use uuid::Uuid;
 const NON_HUMAN_HANDS_LIMIT: u32 = 3;
 
 #[derive(Debug)]
-pub struct Game {
-    hub_addr: Option<Addr<GameHub>>, // needs to be able to communicate back to the hub sometimes
+pub struct Table {
+    hub_addr: Option<Addr<TableHub>>, // needs to be able to communicate back to the hub sometimes
     pub name: String,
     deck: Box<dyn Deck>,
     players: [Option<Player>; 9], // 9 spots where players can sit
@@ -38,11 +38,11 @@ pub struct Game {
 }
 
 /// useful for unit tests, for example
-impl Default for Game {
+impl Default for Table {
     fn default() -> Self {
         Self {
             hub_addr: None,
-            name: "Game".to_owned(),
+            name: "Table".to_owned(),
             deck: Box::new(StandardDeck::new()),
             players: Default::default(),
             player_ids_to_configs: HashMap::<Uuid, PlayerConfig>::new(),
@@ -58,11 +58,11 @@ impl Default for Game {
     }
 }
 
-impl Game {
-    /// the address of the GameHub is optional so that unit tests need not worry about it
+impl Table {
+    /// the address of the TableHub is optional so that unit tests need not worry about it
     /// We can pass in a custom Deck object, but if not, we will just construct a StandardDeck
     pub fn new(
-        hub_addr: Addr<GameHub>,
+        hub_addr: Addr<TableHub>,
         name: String,
         deck_opt: Option<Box<dyn Deck>>,
         max_players: u8, // how many will we let in the game
@@ -77,7 +77,7 @@ impl Game {
         } else {
             Box::new(StandardDeck::new())
         };
-        Game {
+        Table {
             hub_addr: Some(hub_addr),
             name,
             deck,
@@ -220,16 +220,16 @@ impl Game {
         &mut self,
         player_config: PlayerConfig,
         password: Option<String>,
-    ) -> Result<usize, JoinGameError> {
+    ) -> Result<usize, JoinTableError> {
         if let Some(game_password) = &self.password {
             if let Some(given_password) = password {
                 if game_password.ne(&given_password) {
                     // the provided password does not match the game password
-                    return Err(JoinGameError::InvalidPassword);
+                    return Err(JoinTableError::InvalidPassword);
                 }
             } else {
                 // we did not provide a password, but the game requires one
-                return Err(JoinGameError::MissingPassword);
+                return Err(JoinTableError::MissingPassword);
             }
         }
         let id = player_config.id; // copy so that we can send the messsage later
@@ -238,7 +238,7 @@ impl Game {
         result
     }
 
-    pub fn add_bot(&mut self, name: String) -> Result<usize, JoinGameError> {
+    pub fn add_bot(&mut self, name: String) -> Result<usize, JoinTableError> {
         let new_bot = Player::new_bot(self.buy_in);
         let new_config = PlayerConfig::new(new_bot.id, Some(name), None);
         self.add_player(new_config, new_bot)
@@ -248,7 +248,7 @@ impl Game {
         &mut self,
         player_config: PlayerConfig,
         player: Player,
-    ) -> Result<usize, JoinGameError> {
+    ) -> Result<usize, JoinTableError> {
         // Kinda weird, but first check if the player is already at the table
         // Could happen if their Leave wasn't completed yet
         // TODO: verify this can actually happen. Unit testable even?
@@ -265,7 +265,7 @@ impl Game {
 
         if self.players.iter().flatten().count() >= self.max_players.into() {
             // we already have as many as we can fit in the game
-            return Err(JoinGameError::GameIsFull);
+            return Err(JoinTableError::GameIsFull);
         }
 
         for (i, player_spot) in self.players.iter_mut().enumerate() {
@@ -277,7 +277,7 @@ impl Game {
             }
         }
         // if we did not early return, then we must have been full
-        Err(JoinGameError::GameIsFull)
+        Err(JoinTableError::GameIsFull)
     }
 
     /// if any of the player configs has not had a heart beat in a long time,
@@ -316,7 +316,7 @@ impl Game {
 
 	    ////
 	    self.handle_meta_actions(&incoming_meta_actions, between_hands, None);
-            println!("checking heart beats in the game play()");
+            println!("checking heart beats in the table play()");
 	    self.handle_player_heart_beats();
             // check if any player left with a meta action or timed out due to heart beat.                 
             // if so, their config will be gone, so now remove the player struct as well.
@@ -355,7 +355,7 @@ impl Game {
                 println!("non human hands == {:?}", non_human_hands);
             }
             if non_human_hands > NON_HUMAN_HANDS_LIMIT {
-                // the game ends no matter what if we haven't had a human after too many turns
+                // the table ends no matter what if we haven't had a human after too many turns
                 break;
             }
 
@@ -372,7 +372,7 @@ impl Game {
             }
 	    
             // wait for next hand
-	    // this is especially needed when there is only one player in the game
+	    // this is especially needed when there is only one player at the table
             let wait_duration = time::Duration::from_secs(1);
             thread::sleep(wait_duration);
 	    
@@ -437,20 +437,20 @@ impl Game {
 		    }
                 }		
                 MetaAction::Join(player_config, password) => {
-                    // add a new player to the game
+                    // add a new player to the table
                     let cloned_config = player_config.clone(); // clone in case we need to send back
                     println!(
-                        "handling join meta action for {:?} inside game = {:?}",
+                        "handling join meta action for {:?} inside table = {:?}",
                         cloned_config.id, &self.name
                     );
                     match self.add_human(player_config, password) {
                         Ok(index) => {
-                            println!("Joining game at index: {}", index);
+                            println!("Joining table at index: {}", index);
 			    self.send_game_state(gamehand, false);
                         }
                         Err(err) => {
                             // we were unable to add the player
-                            println!("unable to join game: {:?}", err);
+                            println!("unable to join table: {:?}", err);
                             if let Some(hub_addr) = &self.hub_addr {
                                 // tell the hub that we left
                                 hub_addr.do_send(Returned {
@@ -463,12 +463,12 @@ impl Game {
                 }
                 MetaAction::Leave(id) => {
                     println!(
-                        "handling leave meta action for {:?} inside game = {:?}. between hands = {}",
+                        "handling leave meta action for {:?} inside table = {:?}. between hands = {}",
                         id, &self.name, between_hands
                     );
                     if let Some(config) = self.player_ids_to_configs.remove(&id) {
                         // note: we don't remove the player from self.players quite yet,
-                        // we use the lack of the config to indicate to the game during a street
+                        // we use the lack of the config to indicate to the table during a street
                         // that a player has left. If they were active at the time, this information
                         // needs to be taken into account
                         let message = object! {
@@ -559,13 +559,13 @@ impl Game {
     }
 
     fn handle_admin_command(&mut self, id: Uuid, admin_command: AdminCommand) {
-	println!("handling admin_command in game: {:?}", admin_command);
+	println!("handling admin_command in table: {:?}", admin_command);
 	if self.admin_id != id {
-	    // the player who entered the admin command is not the game's admin!
+	    // the player who entered the admin command is not the table's admin!
 	    let message = object! {
 		msg_type: "error".to_owned(),
 		error: "not_admin".to_owned(),
-                reason: "You cannot update a game that you are not the admin for.".to_owned(),
+                reason: "You cannot update a table that you are not the admin for.".to_owned(),
 	    };
 	    PlayerConfig::send_specific_message(
 		&message.dump(),
@@ -576,11 +576,11 @@ impl Game {
 	}
 	
 	if self.password.is_none() {
-	    // only private (i.e. password-protected) games can be updated
+	    // only private (i.e. password-protected) table can be updated
 	    let message = object! {
 		msg_type: "error".to_owned(),
 		error: "not_private".to_owned(),
-                reason: "You cannot update a game that is not private.".to_owned(),
+                reason: "You cannot update a table that is not private.".to_owned(),
 	    };
 	    PlayerConfig::send_specific_message(
 		&message.dump(),
@@ -627,7 +627,7 @@ impl Game {
 		let pass_str = if let Some(password) = &self.password {
 		    format!("The password is {:?}", password)
 		} else {
-		   "The game has no password".to_string()
+		   "The table has no password".to_string()
 		};
 		object! {
 		    msg_type: "admin_success".to_owned(),
@@ -678,7 +678,7 @@ impl Game {
 		    object! {
 			msg_type: "error".to_owned(),
 			error: "unable_to_remove_bot".to_owned(),
-			reason: "Unable to remove a bot from the game.".to_owned(),
+			reason: "Unable to remove a bot from the table.".to_owned(),
 		    }
 		}
 	    }
@@ -929,11 +929,6 @@ impl Game {
                 &self.player_ids_to_configs,
             );
         }
-
-        // each index keeps track of that players' contribution this street
-        //let mut cumulative_bets = [0; 9];
-	// attach the cumulative bets from this street to the game hand map
-	//gamehand.street_contributions.insert(gamehand.street, cumulative_bets);	
 	
         let starting_idx = self.get_starting_idx(); // which player starts the betting
 
@@ -1084,7 +1079,7 @@ impl Game {
     }
     
     /// if the player is a human, then we look for their action in the incoming_actions hashmap
-    /// this value is set by the game hub when handling a message from a player client
+    /// this value is set by the table hub when handling a message from a player client
     fn get_action_from_player(
         &self,
         incoming_actions: &Arc<Mutex<HashMap<Uuid, PlayerAction>>>,
@@ -1339,42 +1334,42 @@ mod tests {
 
     #[test]
     fn add_bot() {
-        let mut game = Game::default();
+        let mut table = Table::default();
         let name = "Mr Bot".to_string();
-        let index = game.add_bot(name);
+        let index = table.add_bot(name);
         assert_eq!(index.unwrap(), 0); // the first position to be added to is index 0
-        assert_eq!(game.players.len(), 9);
+        assert_eq!(table.players.len(), 9);
         // flatten to get all the Some() players
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 1);
-        assert!(!game.players[0].as_ref().unwrap().human_controlled);
+        assert!(!table.players[0].as_ref().unwrap().human_controlled);
     }
 
     #[test]
     fn add_human() {
-        let mut game = Game::default();
+        let mut table = Table::default();
         let id = uuid::Uuid::new_v4();
         let name = "Human".to_string();
         let settings = PlayerConfig::new(id, Some(name), None);
-        game.add_human(settings, None).expect("could not add user");
-        assert_eq!(game.players.len(), 9);
+        table.add_human(settings, None).expect("could not add user");
+        assert_eq!(table.players.len(), 9);
         // flatten to get all the Some() players
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 1);
-        assert!(game.players[0].as_ref().unwrap().human_controlled);
+        assert!(table.players[0].as_ref().unwrap().human_controlled);
     }
 
     /// test that a player can join with the correct password
     #[test]
     fn add_human_password_success() {
-        let mut game = Game::default();
+        let mut table = Table::default();
         //let _incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         //let cloned_actions = incoming_actions.clone();
         let cloned_meta_actions = incoming_meta_actions.clone();
 
         let password = "123".to_string();
-        game.password = Some(password.clone());
+        table.password = Some(password.clone());
 
         let id = uuid::Uuid::new_v4();
         let name = "Human".to_string();
@@ -1385,22 +1380,22 @@ mod tests {
             .unwrap()
             .push_back(MetaAction::Join(settings, Some(password)));
 
-        game.handle_meta_actions(&cloned_meta_actions, true, None);
-        assert_eq!(game.players.len(), 9);
+        table.handle_meta_actions(&cloned_meta_actions, true, None);
+        assert_eq!(table.players.len(), 9);
         // flatten to get all the Some() players
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 1);
-        assert!(game.players[0].as_ref().unwrap().human_controlled);
+        assert!(table.players[0].as_ref().unwrap().human_controlled);
     }
 
     /// test that a player can NOT join with the incorrect password
     #[test]
     fn add_human_password_fail() {
-        let mut game = Game::default();
+        let mut table = Table::default();
         //let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
 
-        game.password = Some("123".to_string());
+        table.password = Some("123".to_string());
 
         let id = uuid::Uuid::new_v4();
         let name = "Human".to_string();
@@ -1411,22 +1406,22 @@ mod tests {
             .unwrap()
             .push_back(MetaAction::Join(settings, Some("345".to_string())));
 
-        game.handle_meta_actions(&incoming_meta_actions, true, None);
+        table.handle_meta_actions(&incoming_meta_actions, true, None);
 	
-        assert_eq!(game.players.len(), 9);
+        assert_eq!(table.players.len(), 9);
         // flatten to get all the Some() players
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 0); // did not make it in
     }
 
     /// test that a player can NOT join without providing a password
     #[test]
     fn add_human_password_missing() {
-        let mut game = Game::default();
+        let mut table = Table::default();
         //let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
 
-        game.password = Some("123".to_string());
+        table.password = Some("123".to_string());
 
         let id = uuid::Uuid::new_v4();
         let name = "Human".to_string();
@@ -1437,11 +1432,11 @@ mod tests {
             .unwrap()
             .push_back(MetaAction::Join(settings, None)); // no password passed in
 
-        game.handle_meta_actions(&incoming_meta_actions, true, None);	
+        table.handle_meta_actions(&incoming_meta_actions, true, None);	
 
-        assert_eq!(game.players.len(), 9);
+        assert_eq!(table.players.len(), 9);
         // flatten to get all the Some() players
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 0); // did not make it in
     }
 
@@ -1449,14 +1444,14 @@ mod tests {
     /// not work
     #[test]
     fn max_players_in_game() {
-        let mut game = Game::default();
+        let mut table = Table::default();
         let max_players = 3;
-        game.max_players = max_players;
+        table.max_players = max_players;
 
         // we TRY to add 5 bots
         for i in 0..5 {
             let name = format!("Bot {}", i);
-            let index = game.add_bot(name);
+            let index = table.add_bot(name);
             if i < max_players {
                 assert_eq!(index.unwrap() as u8, i);
             } else {
@@ -1465,10 +1460,10 @@ mod tests {
                 assert!(index.is_err());
             }
         }
-        assert_eq!(game.players.len(), 9); // len of players always simply 9
+        assert_eq!(table.players.len(), 9); // len of players always simply 9
 
         // flatten to get all the Some() players
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         // but only max_players players are in the game at the end
         assert_eq!(some_players as u8, max_players);
     }
@@ -1476,7 +1471,7 @@ mod tests {
     /// the small blind folds, so the big blind should win and get paid
     #[test]
     fn instant_fold() {
-        let mut game = Game::default();
+        let mut table = Table::default();
         let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         let cloned_actions = incoming_actions.clone();
@@ -1486,20 +1481,20 @@ mod tests {
         let id1 = uuid::Uuid::new_v4();
         let name1 = "Human1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
-        game.add_human(settings1, None).unwrap();
+        table.add_human(settings1, None).unwrap();
 
         // player2 will start as the small blind
         let id2 = uuid::Uuid::new_v4();
         let name2 = "Human1".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
-        game.add_human(settings2, None).unwrap();
+        table.add_human(settings2, None).unwrap();
         // flatten to get all the Some() players
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 2);
-        assert!(game.players[0].as_ref().unwrap().human_controlled);
+        assert!(table.players[0].as_ref().unwrap().human_controlled);
 
         let handler = std::thread::spawn(move || {
-            game.play_one_hand(&cloned_actions, &cloned_meta_actions);
+            table.play_one_hand(&cloned_actions, &cloned_meta_actions);
             game // return the game back
         });
 
@@ -1513,15 +1508,15 @@ mod tests {
         let game = handler.join().unwrap();
 
         // check that the money changed hands
-        assert_eq!(game.players[0].as_ref().unwrap().money, 1004);
-        assert_eq!(game.players[1].as_ref().unwrap().money, 996);
+        assert_eq!(table.players[0].as_ref().unwrap().money, 1004);
+        assert_eq!(table.players[1].as_ref().unwrap().money, 996);
     }
 
     /// the small blind calls, the big blind checks to the flop
     /// the small blind bets on the flop, and the big blind folds
     #[test]
     fn call_check_bet_fold() {
-        let mut game = Game::default();
+        let mut table = Table::default();
         let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         let cloned_actions = incoming_actions.clone();
@@ -1531,20 +1526,20 @@ mod tests {
         let id1 = uuid::Uuid::new_v4();
         let name1 = "Human1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
-        game.add_human(settings1, None).unwrap();
+        table.add_human(settings1, None).unwrap();
 
         // player2 will start as the small blind
         let id2 = uuid::Uuid::new_v4();
         let name2 = "Human1".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
-        game.add_human(settings2, None).unwrap();
+        table.add_human(settings2, None).unwrap();
         // flatten to get all the Some() players
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 2);
-        assert!(game.players[0].as_ref().unwrap().human_controlled);
+        assert!(table.players[0].as_ref().unwrap().human_controlled);
 
         let handler = std::thread::spawn(move || {
-            game.play_one_hand(&cloned_actions, &cloned_meta_actions);
+            table.play_one_hand(&cloned_actions, &cloned_meta_actions);
             game // return the game back
         });
 
@@ -1579,14 +1574,14 @@ mod tests {
         let game = handler.join().unwrap();
 
         // check that the money changed hands
-        assert_eq!(game.players[0].as_ref().unwrap().money, 992);
-        assert_eq!(game.players[1].as_ref().unwrap().money, 1008);
+        assert_eq!(table.players[0].as_ref().unwrap().money, 992);
+        assert_eq!(table.players[1].as_ref().unwrap().money, 1008);
     }
 
     /// the small blind bets, the big blind folds
     #[test]
     fn pre_flop_bet_fold() {
-        let mut game = Game::default();
+        let mut table = Table::default();
         let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         let cloned_actions = incoming_actions.clone();
@@ -1596,20 +1591,20 @@ mod tests {
         let id1 = uuid::Uuid::new_v4();
         let name1 = "Human1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
-        game.add_human(settings1, None).unwrap();
+        table.add_human(settings1, None).unwrap();
 
         // player2 will start as the small blind
         let id2 = uuid::Uuid::new_v4();
         let name2 = "Human1".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
-        game.add_human(settings2, None).unwrap();
+        table.add_human(settings2, None).unwrap();
         // flatten to get all the Some() players
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 2);
-        assert!(game.players[0].as_ref().unwrap().human_controlled);
+        assert!(table.players[0].as_ref().unwrap().human_controlled);
 
         let handler = std::thread::spawn(move || {
-            game.play_one_hand(&cloned_actions, &cloned_meta_actions);
+            table.play_one_hand(&cloned_actions, &cloned_meta_actions);
             game // return the game back
         });
 
@@ -1631,8 +1626,8 @@ mod tests {
         let game = handler.join().unwrap();
 
         // check that the money changed hands
-        assert_eq!(game.players[0].as_ref().unwrap().money, 992);
-        assert_eq!(game.players[1].as_ref().unwrap().money, 1008);
+        assert_eq!(table.players[0].as_ref().unwrap().money, 992);
+        assert_eq!(table.players[1].as_ref().unwrap().money, 1008);
     }
 
     /// if the big blind player doesn't have enough to post the big blind amount,
@@ -1681,8 +1676,8 @@ mod tests {
             suit: Suit::Club,
         });
 
-        let mut game = Game::default();
-        game.deck = Box::new(deck);
+        let mut table = Table::default();
+        table.deck = Box::new(deck);
 
         let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
@@ -1693,20 +1688,20 @@ mod tests {
         let id1 = uuid::Uuid::new_v4();
         let name1 = "Human1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
-        game.add_human(settings1, None).unwrap();
-        game.players[0].as_mut().unwrap().money = 3; // set the player to have less than the norm 8 BB
+        table.add_human(settings1, None).unwrap();
+        table.players[0].as_mut().unwrap().money = 3; // set the player to have less than the norm 8 BB
 
         // player2 will start as the small blind
         let id2 = uuid::Uuid::new_v4();
         let name2 = "Human1".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
-        game.add_human(settings2, None).unwrap();
+        table.add_human(settings2, None).unwrap();
         // flatten to get all the Some() players
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 2);
 
         let handler = std::thread::spawn(move || {
-            game.play_one_hand(&cloned_actions, &cloned_meta_actions);
+            table.play_one_hand(&cloned_actions, &cloned_meta_actions);
             game // return the game back
         });
 
@@ -1724,15 +1719,15 @@ mod tests {
         let game = handler.join().unwrap();
 
         // check that the money changed hands
-        assert_eq!(game.players[0].as_ref().unwrap().money, 6);
-        assert_eq!(game.players[1].as_ref().unwrap().money, 997);
+        assert_eq!(table.players[0].as_ref().unwrap().money, 6);
+        assert_eq!(table.players[1].as_ref().unwrap().money, 997);
     }
 
     /// the small blind bets, the big blind calls
     /// the small blind bets on the flop, and the big blind folds
     #[test]
     fn bet_call_bet_fold() {
-        let mut game = Game::default();
+        let mut table = Table::default();
         let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         let cloned_actions = incoming_actions.clone();
@@ -1742,20 +1737,20 @@ mod tests {
         let id1 = uuid::Uuid::new_v4();
         let name1 = "Human1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
-        game.add_human(settings1, None).unwrap();
+        table.add_human(settings1, None).unwrap();
 
         // player2 will start as the small blind
         let id2 = uuid::Uuid::new_v4();
         let name2 = "Human1".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
-        game.add_human(settings2, None).unwrap();
+        table.add_human(settings2, None).unwrap();
         // flatten to get all the Some() players
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 2);
-        assert!(game.players[0].as_ref().unwrap().human_controlled);
+        assert!(table.players[0].as_ref().unwrap().human_controlled);
 
         let handler = std::thread::spawn(move || {
-            game.play_one_hand(&cloned_actions, &cloned_meta_actions);
+            table.play_one_hand(&cloned_actions, &cloned_meta_actions);
             game // return the game back
         });
 	
@@ -1793,8 +1788,8 @@ mod tests {
         let game = handler.join().unwrap();
 
         // check that the money changed hands
-        assert_eq!(game.players[0].as_ref().unwrap().money, 978);
-        assert_eq!(game.players[1].as_ref().unwrap().money, 1022);
+        assert_eq!(table.players[0].as_ref().unwrap().money, 978);
+        assert_eq!(table.players[1].as_ref().unwrap().money, 1022);
     }
 
     /// the small blind goes all in and the big blind calls
@@ -1844,8 +1839,8 @@ mod tests {
             suit: Suit::Club,
         });
 
-        let mut game = Game::default();
-        game.deck = Box::new(deck);
+        let mut table = Table::default();
+        table.deck = Box::new(deck);
         let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         let cloned_actions = incoming_actions.clone();
@@ -1855,20 +1850,20 @@ mod tests {
         let id1 = uuid::Uuid::new_v4();
         let name1 = "Human1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
-        game.add_human(settings1, None).unwrap();
+        table.add_human(settings1, None).unwrap();
 
         // player2 will start as the small blind
         let id2 = uuid::Uuid::new_v4();
         let name2 = "Human1".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
-        game.add_human(settings2, None).unwrap();
+        table.add_human(settings2, None).unwrap();
         // flatten to get all the Some() players
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 2);
-        assert!(game.players[0].as_ref().unwrap().human_controlled);
+        assert!(table.players[0].as_ref().unwrap().human_controlled);
 
         let handler = std::thread::spawn(move || {
-            game.play_one_hand(&cloned_actions, &cloned_meta_actions);
+            table.play_one_hand(&cloned_actions, &cloned_meta_actions);
             game // return the game back
         });
 
@@ -1890,8 +1885,8 @@ mod tests {
         let game = handler.join().unwrap();
 
         // the small blind won
-        assert_eq!(game.players[0].as_ref().unwrap().money, 0);
-        assert_eq!(game.players[1].as_ref().unwrap().money, 2000);
+        assert_eq!(table.players[0].as_ref().unwrap().money, 0);
+        assert_eq!(table.players[1].as_ref().unwrap().money, 2000);
     }
 
     /// the small blind bets and the big blind calls
@@ -1942,8 +1937,8 @@ mod tests {
             suit: Suit::Club,
         });
 
-        let mut game = Game::default();
-        game.deck = Box::new(deck);
+        let mut table = Table::default();
+        table.deck = Box::new(deck);
         let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         let cloned_actions = incoming_actions.clone();
@@ -1953,22 +1948,22 @@ mod tests {
         let id1 = uuid::Uuid::new_v4();
         let name1 = "Human1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
-        game.add_human(settings1, None).unwrap();
+        table.add_human(settings1, None).unwrap();
 
-        game.players[0].as_mut().unwrap().money = 500; // set the player to have less money
+        table.players[0].as_mut().unwrap().money = 500; // set the player to have less money
 
         // player2 will start as the small blind
         let id2 = uuid::Uuid::new_v4();
         let name2 = "Human1".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
-        game.add_human(settings2, None).unwrap();
+        table.add_human(settings2, None).unwrap();
         // flatten to get all the Some() players
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 2);
-        assert!(game.players[0].as_ref().unwrap().human_controlled);
+        assert!(table.players[0].as_ref().unwrap().human_controlled);
 
         let handler = std::thread::spawn(move || {
-            game.play_one_hand(&cloned_actions, &cloned_meta_actions);
+            table.play_one_hand(&cloned_actions, &cloned_meta_actions);
             game // return the game back
         });
 
@@ -1990,8 +1985,8 @@ mod tests {
         let game = handler.join().unwrap();
 
         // the small blind won
-        assert_eq!(game.players[0].as_ref().unwrap().money, 0);
-        assert_eq!(game.players[1].as_ref().unwrap().money, 1500);
+        assert_eq!(table.players[0].as_ref().unwrap().money, 0);
+        assert_eq!(table.players[1].as_ref().unwrap().money, 1500);
     }
 
     /// the small blind bets and the big blind calls
@@ -2044,8 +2039,8 @@ mod tests {
             suit: Suit::Club,
         });
 
-        let mut game = Game::default();
-        game.deck = Box::new(deck);
+        let mut table = Table::default();
+        table.deck = Box::new(deck);
         let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         let cloned_actions = incoming_actions.clone();
@@ -2055,22 +2050,22 @@ mod tests {
         let id1 = uuid::Uuid::new_v4();
         let name1 = "Big".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
-        game.add_human(settings1, None).unwrap();
+        table.add_human(settings1, None).unwrap();
 
-        game.players[0].as_mut().unwrap().money = 500; // set the player to have less money
+        table.players[0].as_mut().unwrap().money = 500; // set the player to have less money
 
         // player2 will start as the small blind
         let id2 = uuid::Uuid::new_v4();
         let name2 = "Small".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
-        game.add_human(settings2, None).unwrap();
+        table.add_human(settings2, None).unwrap();
         // flatten to get all the Some() players
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 2);
-        assert!(game.players[0].as_ref().unwrap().human_controlled);
+        assert!(table.players[0].as_ref().unwrap().human_controlled);
 
         let handler = std::thread::spawn(move || {
-            game.play_one_hand(&cloned_actions, &cloned_meta_actions);
+            table.play_one_hand(&cloned_actions, &cloned_meta_actions);
             game // return the game back
         });
 
@@ -2092,10 +2087,10 @@ mod tests {
         let game = handler.join().unwrap();
 
         // the big blind caller won, but only doubles its money
-        assert_eq!(game.players[0].as_ref().unwrap().money, 1000);
+        assert_eq!(table.players[0].as_ref().unwrap().money, 1000);
 
         // the small blind only loses half
-        assert_eq!(game.players[1].as_ref().unwrap().money, 500);
+        assert_eq!(table.players[1].as_ref().unwrap().money, 500);
     }
 
     /// if a player goes all-in, then can only win as much as is called up to that amount,
@@ -2158,8 +2153,8 @@ mod tests {
             suit: Suit::Club,
         });
 
-        let mut game = Game::default();
-        game.deck = Box::new(deck);
+        let mut table = Table::default();
+        table.deck = Box::new(deck);
         let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         let cloned_actions = incoming_actions.clone();
@@ -2169,31 +2164,31 @@ mod tests {
         let id1 = uuid::Uuid::new_v4();
         let name1 = "Button".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
-        game.add_human(settings1, None).unwrap();
+        table.add_human(settings1, None).unwrap();
         // set the button to have less money so there is a side pot
-        game.players[0].as_mut().unwrap().money = 500;
+        table.players[0].as_mut().unwrap().money = 500;
 
         // player2 will start as the small blind
         let id2 = uuid::Uuid::new_v4();
         let name2 = "Small".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
-        game.add_human(settings2, None).unwrap();
+        table.add_human(settings2, None).unwrap();
 
         // player3 will start as the big blind
         let id3 = uuid::Uuid::new_v4();
         let name3 = "Big".to_string();
         let settings3 = PlayerConfig::new(id3, Some(name3), None);
-        game.add_human(settings3, None).unwrap();
+        table.add_human(settings3, None).unwrap();
 
         // flatten to get all the Some() players
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 3);
-        assert!(game.players[0].as_ref().unwrap().human_controlled);
-        assert!(game.players[1].as_ref().unwrap().human_controlled);
-        assert!(game.players[2].as_ref().unwrap().human_controlled);
+        assert!(table.players[0].as_ref().unwrap().human_controlled);
+        assert!(table.players[1].as_ref().unwrap().human_controlled);
+        assert!(table.players[2].as_ref().unwrap().human_controlled);
 
         let handler = std::thread::spawn(move || {
-            game.play_one_hand(&cloned_actions, &cloned_meta_actions);
+            table.play_one_hand(&cloned_actions, &cloned_meta_actions);
             game // return the game back
         });
 
@@ -2220,13 +2215,13 @@ mod tests {
         let game = handler.join().unwrap();
 
         // the button won the side pot
-        assert_eq!(game.players[0].as_ref().unwrap().money, 1500);
+        assert_eq!(table.players[0].as_ref().unwrap().money, 1500);
 
         // the small blind won the remainder
-        assert_eq!(game.players[1].as_ref().unwrap().money, 1000);
+        assert_eq!(table.players[1].as_ref().unwrap().money, 1000);
 
         // the big blind lost everything
-        assert_eq!(game.players[2].as_ref().unwrap().money, 0);
+        assert_eq!(table.players[2].as_ref().unwrap().money, 0);
     }
 
     /// if a player goes all-in, then can only win as much as is called up to that amount,
@@ -2289,8 +2284,8 @@ mod tests {
             suit: Suit::Club,
         });
 
-        let mut game = Game::default();
-        game.deck = Box::new(deck);
+        let mut table = Table::default();
+        table.deck = Box::new(deck);
         let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         let cloned_actions = incoming_actions.clone();
@@ -2300,31 +2295,31 @@ mod tests {
         let id1 = uuid::Uuid::new_v4();
         let name1 = "Button".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
-        game.add_human(settings1, None).unwrap();
+        table.add_human(settings1, None).unwrap();
         // set the button to have less money so there is a side pot
-        game.players[0].as_mut().unwrap().money = 500;
+        table.players[0].as_mut().unwrap().money = 500;
 
         // player2 will start as the small blind
         let id2 = uuid::Uuid::new_v4();
         let name2 = "Small".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
-        game.add_human(settings2, None).unwrap();
+        table.add_human(settings2, None).unwrap();
 
         // player3 will start as the big blind
         let id3 = uuid::Uuid::new_v4();
         let name3 = "Big".to_string();
         let settings3 = PlayerConfig::new(id3, Some(name3), None);
-        game.add_human(settings3, None).unwrap();
+        table.add_human(settings3, None).unwrap();
 
         // flatten to get all the Some() players
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 3);
-        assert!(game.players[0].as_ref().unwrap().human_controlled);
-        assert!(game.players[1].as_ref().unwrap().human_controlled);
-        assert!(game.players[2].as_ref().unwrap().human_controlled);
+        assert!(table.players[0].as_ref().unwrap().human_controlled);
+        assert!(table.players[1].as_ref().unwrap().human_controlled);
+        assert!(table.players[2].as_ref().unwrap().human_controlled);
 
         let handler = std::thread::spawn(move || {
-            game.play_one_hand(&cloned_actions, &cloned_meta_actions);
+            table.play_one_hand(&cloned_actions, &cloned_meta_actions);
             game // return the game back
         });
 
@@ -2351,13 +2346,13 @@ mod tests {
         let game = handler.join().unwrap();
 
         // the button won the side pot
-        assert_eq!(game.players[0].as_ref().unwrap().money, 750);
+        assert_eq!(table.players[0].as_ref().unwrap().money, 750);
 
         // the small blind won the remainder
-        assert_eq!(game.players[1].as_ref().unwrap().money, 1750);
+        assert_eq!(table.players[1].as_ref().unwrap().money, 1750);
 
         // the big blind lost everything
-        assert_eq!(game.players[2].as_ref().unwrap().money, 0);
+        assert_eq!(table.players[2].as_ref().unwrap().money, 0);
     }
 
     /// if a player goes all-in, then can only win as much as is called up to that amount,
@@ -2431,8 +2426,8 @@ mod tests {
             suit: Suit::Club,
         });
 
-        let mut game = Game::default();
-        game.deck = Box::new(deck);
+        let mut table = Table::default();
+        table.deck = Box::new(deck);
         let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         let cloned_actions = incoming_actions.clone();
@@ -2442,40 +2437,40 @@ mod tests {
         let id1 = uuid::Uuid::new_v4();
         let name1 = "Button".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
-        game.add_human(settings1, None).unwrap();
+        table.add_human(settings1, None).unwrap();
         // set the button to have less money so there is a side pot
-        game.players[0].as_mut().unwrap().money = 500;
+        table.players[0].as_mut().unwrap().money = 500;
 
         // player2 will start as the small blind
         let id2 = uuid::Uuid::new_v4();
         let name2 = "Small".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
-        game.add_human(settings2, None).unwrap();
+        table.add_human(settings2, None).unwrap();
 
         // player3 will start as the big blind
         let id3 = uuid::Uuid::new_v4();
         let name3 = "Big".to_string();
         let settings3 = PlayerConfig::new(id3, Some(name3), None);
-        game.add_human(settings3, None).unwrap();
+        table.add_human(settings3, None).unwrap();
 
         // player4 will start as UTG
         let id4 = uuid::Uuid::new_v4();
         let name4 = "UTG".to_string();
         let settings4 = PlayerConfig::new(id4, Some(name4), None);
-        game.add_human(settings4, None).unwrap();
+        table.add_human(settings4, None).unwrap();
         // set UTG to have medium money so there is a second side pot
-        game.players[3].as_mut().unwrap().money = 750;
+        table.players[3].as_mut().unwrap().money = 750;
 
         // flatten to get all the Some() players
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 4);
-        assert!(game.players[0].as_ref().unwrap().human_controlled);
-        assert!(game.players[1].as_ref().unwrap().human_controlled);
-        assert!(game.players[2].as_ref().unwrap().human_controlled);
-        assert!(game.players[3].as_ref().unwrap().human_controlled);
+        assert!(table.players[0].as_ref().unwrap().human_controlled);
+        assert!(table.players[1].as_ref().unwrap().human_controlled);
+        assert!(table.players[2].as_ref().unwrap().human_controlled);
+        assert!(table.players[3].as_ref().unwrap().human_controlled);
 
         let handler = std::thread::spawn(move || {
-            game.play_one_hand(&cloned_actions, &cloned_meta_actions);
+            table.play_one_hand(&cloned_actions, &cloned_meta_actions);
             game // return the game back
         });
 
@@ -2507,22 +2502,22 @@ mod tests {
         let game = handler.join().unwrap();
 
         // the button won the side pot
-        assert_eq!(game.players[0].as_ref().unwrap().money, 2000);
+        assert_eq!(table.players[0].as_ref().unwrap().money, 2000);
 
         // the small blind won the remainder
-        assert_eq!(game.players[1].as_ref().unwrap().money, 500);
+        assert_eq!(table.players[1].as_ref().unwrap().money, 500);
 
         // the big blind lost everything
-        assert_eq!(game.players[2].as_ref().unwrap().money, 0);
+        assert_eq!(table.players[2].as_ref().unwrap().money, 0);
 
         // UTG won the second side pot
-        assert_eq!(game.players[3].as_ref().unwrap().money, 750);
+        assert_eq!(table.players[3].as_ref().unwrap().money, 750);
     }
 
     /// can we pass a hand limit of 2 and the game comes to an end
     #[test]
     fn hand_limit() {
-        let mut game = Game::default();
+        let mut table = Table::default();
         let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         let cloned_actions = incoming_actions.clone();
@@ -2532,20 +2527,20 @@ mod tests {
         let id1 = uuid::Uuid::new_v4();
         let name1 = "Human1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
-        game.add_human(settings1, None).unwrap();
+        table.add_human(settings1, None).unwrap();
 
         // player2 will start as the small blind
         let id2 = uuid::Uuid::new_v4();
         let name2 = "Human1".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
-        game.add_human(settings2, None).unwrap();
+        table.add_human(settings2, None).unwrap();
         // flatten to get all the Some() players
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 2);
-        assert!(game.players[0].as_ref().unwrap().human_controlled);
+        assert!(table.players[0].as_ref().unwrap().human_controlled);
 
         let handler = std::thread::spawn(move || {
-            game.play(&cloned_actions, &cloned_meta_actions, Some(2));
+            table.play(&cloned_actions, &cloned_meta_actions, Some(2));
             game // return the game back
         });
 
@@ -2571,8 +2566,8 @@ mod tests {
         let game = handler.join().unwrap();
 
         // check that the money balances out
-        assert_eq!(game.players[0].as_ref().unwrap().money, 1000);
-        assert_eq!(game.players[1].as_ref().unwrap().money, 1000);
+        assert_eq!(table.players[0].as_ref().unwrap().money, 1000);
+        assert_eq!(table.players[1].as_ref().unwrap().money, 1000);
     }
     /// the game should end after N hands if there are no human players in the game
     /// even if there is no hand limit or a high hand limit
@@ -2580,7 +2575,7 @@ mod tests {
     /// as a hand "played", so we can check that the game ends with the proper count
     #[test]
     fn end_early() {
-        let mut game = Game::default();
+        let mut table = Table::default();
         let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         let cloned_actions = incoming_actions.clone();
@@ -2588,7 +2583,7 @@ mod tests {
 
         let handler = std::thread::spawn(move || {
             // we start the game with None hand limit!
-            game.play(&cloned_actions, &cloned_meta_actions, None);
+            table.play(&cloned_actions, &cloned_meta_actions, None);
             game // return the game back
         });
 
@@ -2596,18 +2591,18 @@ mod tests {
         let game = handler.join().unwrap();
 
         // check that the game ended with 1 more than the limit turns "played"
-        assert_eq!(game.hands_played, NON_HUMAN_HANDS_LIMIT + 1);
+        assert_eq!(table.hands_played, NON_HUMAN_HANDS_LIMIT + 1);
     }
 
     /// check that the button moves around properly
     /// we play 4 hands with 3 players with everyone folding whenever it gets to them,
     /// Note: we sleep several seconds in the test to let the game finish its hand in its thread,
-    /// so the test is brittle to changes in wait durations within the game.
+    /// so the test is brittle to changes in wait durations within the table.
     /// If this test starts failing in the future, it is likely just a matter of tweaking the sleep
     /// durations
     #[test]
     fn button_movement() {
-        let mut game = Game::default();
+        let mut table = Table::default();
         let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         let cloned_actions = incoming_actions.clone();
@@ -2616,26 +2611,26 @@ mod tests {
         let id1 = uuid::Uuid::new_v4();
         let name1 = "Human1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
-        game.add_human(settings1, None).unwrap();
+        table.add_human(settings1, None).unwrap();
 
         let id2 = uuid::Uuid::new_v4();
         let name2 = "Human2".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
-        game.add_human(settings2, None).unwrap();
+        table.add_human(settings2, None).unwrap();
 
         let id3 = uuid::Uuid::new_v4();
         let name3 = "Human3".to_string();
         let settings3 = PlayerConfig::new(id3, Some(name3), None);
-        game.add_human(settings3, None).unwrap();
+        table.add_human(settings3, None).unwrap();
 
         // flatten to get all the Some() players
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 3);
-        assert!(game.players[0].as_ref().unwrap().human_controlled);
+        assert!(table.players[0].as_ref().unwrap().human_controlled);
 
         let num_hands = 4;
         let handler = std::thread::spawn(move || {
-            game.play(&cloned_actions, &cloned_meta_actions, Some(num_hands));
+            table.play(&cloned_actions, &cloned_meta_actions, Some(num_hands));
             game // return the game back
         });
 
@@ -2703,9 +2698,9 @@ mod tests {
 
         // Everyone lost their small blind and won someone else's small blind
         // then in the last hand, id3 won the small blind from id2
-        assert_eq!(game.players[0].as_ref().unwrap().money, 1000);
-        assert_eq!(game.players[1].as_ref().unwrap().money, 996);
-        assert_eq!(game.players[2].as_ref().unwrap().money, 1004);
+        assert_eq!(table.players[0].as_ref().unwrap().money, 1000);
+        assert_eq!(table.players[1].as_ref().unwrap().money, 996);
+        assert_eq!(table.players[2].as_ref().unwrap().money, 1004);
     }
 
     /// the small blind calls, the big blind checks to the flop
@@ -2713,7 +2708,7 @@ mod tests {
     /// a player joins during the hand, and it works fine
     #[test]
     fn join_mid_hand() {
-        let mut game = Game::default();
+        let mut table = Table::default();
         let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         let cloned_actions = incoming_actions.clone();
@@ -2723,20 +2718,20 @@ mod tests {
         let id1 = uuid::Uuid::new_v4();
         let name1 = "Human1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
-        game.add_human(settings1, None).unwrap();
+        table.add_human(settings1, None).unwrap();
 
         // player2 will start as the small blind
         let id2 = uuid::Uuid::new_v4();
         let name2 = "Human2".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
-        game.add_human(settings2, None).unwrap();
+        table.add_human(settings2, None).unwrap();
         // flatten to get all the Some() players
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 2);
-        assert!(game.players[0].as_ref().unwrap().human_controlled);
+        assert!(table.players[0].as_ref().unwrap().human_controlled);
 
         let handler = std::thread::spawn(move || {
-            game.play_one_hand(&cloned_actions, &cloned_meta_actions);
+            table.play_one_hand(&cloned_actions, &cloned_meta_actions);
             game // return the game back
         });
 
@@ -2784,14 +2779,14 @@ mod tests {
         let game = handler.join().unwrap();
 
         // there is another player now
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 3);
 
         // check that the money changed hands
-        assert_eq!(game.players[0].as_ref().unwrap().money, 992);
-        assert_eq!(game.players[1].as_ref().unwrap().money, 1008);
-        assert_eq!(game.players[2].as_ref().unwrap().money, 1000);
-        assert!(!game.players[2].as_ref().unwrap().is_active);
+        assert_eq!(table.players[0].as_ref().unwrap().money, 992);
+        assert_eq!(table.players[1].as_ref().unwrap().money, 1008);
+        assert_eq!(table.players[2].as_ref().unwrap().money, 1000);
+        assert!(!table.players[2].as_ref().unwrap().is_active);
     }
 
     /// player1 has the best hand, but chooses to sit out mid hand,
@@ -2835,8 +2830,8 @@ mod tests {
             suit: Suit::Heart,
         });
 
-        let mut game = Game::default();
-        game.deck = Box::new(deck);
+        let mut table = Table::default();
+        table.deck = Box::new(deck);
         let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         let cloned_actions = incoming_actions.clone();
@@ -2846,18 +2841,18 @@ mod tests {
         let id1 = uuid::Uuid::new_v4();
         let name1 = "Human1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
-        game.add_human(settings1, None).unwrap();
+        table.add_human(settings1, None).unwrap();
 
         // player2 will start as the small blind
         let id2 = uuid::Uuid::new_v4();
         let name2 = "Human2".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
-        game.add_human(settings2, None).unwrap();
+        table.add_human(settings2, None).unwrap();
 
         // flatten to get all the Some() players
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 2);
-        assert!(game.players[0].as_ref().unwrap().human_controlled);
+        assert!(table.players[0].as_ref().unwrap().human_controlled);
 
         // both players not sitting out to start
         let not_sitting_out = game
@@ -2869,7 +2864,7 @@ mod tests {
         assert_eq!(not_sitting_out, 2);
 
         let handler = std::thread::spawn(move || {
-            game.play_one_hand(&cloned_actions, &cloned_meta_actions);
+            table.play_one_hand(&cloned_actions, &cloned_meta_actions);
             game // return the game back
         });
 
@@ -2917,9 +2912,9 @@ mod tests {
         assert_eq!(not_sitting_out, 1);
 
         // check that the money changed hands
-        assert_eq!(game.players[0].as_ref().unwrap().money, 992);
-        assert_eq!(game.players[1].as_ref().unwrap().money, 1008);
-        assert!(!game.players[0].as_ref().unwrap().is_active);
+        assert_eq!(table.players[0].as_ref().unwrap().money, 992);
+        assert_eq!(table.players[1].as_ref().unwrap().money, 1008);
+        assert!(!table.players[0].as_ref().unwrap().is_active);
     }
     /// player1 has the best hand, but chooses to leave out mid hand,
     /// This leads to a fold and player2 winning the pot
@@ -2962,8 +2957,8 @@ mod tests {
             suit: Suit::Heart,
         });
 
-        let mut game = Game::default();
-        game.deck = Box::new(deck);
+        let mut table = Table::default();
+        table.deck = Box::new(deck);
         let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         let cloned_actions = incoming_actions.clone();
@@ -2973,21 +2968,21 @@ mod tests {
         let id1 = uuid::Uuid::new_v4();
         let name1 = "Human1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
-        game.add_human(settings1, None).unwrap();
+        table.add_human(settings1, None).unwrap();
 
         // player2 will start as the small blind
         let id2 = uuid::Uuid::new_v4();
         let name2 = "Human2".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
-        game.add_human(settings2, None).unwrap();
+        table.add_human(settings2, None).unwrap();
 
         // flatten to get all the Some() players
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 2);
-        assert!(game.players[0].as_ref().unwrap().human_controlled);
+        assert!(table.players[0].as_ref().unwrap().human_controlled);
 
         let handler = std::thread::spawn(move || {
-            game.play_one_hand(&cloned_actions, &cloned_meta_actions);
+            table.play_one_hand(&cloned_actions, &cloned_meta_actions);
             game // return the game back
         });
 
@@ -3011,32 +3006,32 @@ mod tests {
 
         // flatten to get all the Some() players
         // now there are only one
-        let some_players = game.players.iter().flatten().count();
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 1);
-        assert_eq!(game.player_ids_to_configs.len(), 1);
+        assert_eq!(table.player_ids_to_configs.len(), 1);
 
         // check that the money changed hands
-        assert!(game.players[0].is_none()); // the spot is empty now
-        assert_eq!(game.players[1].as_ref().unwrap().money, 1008);
+        assert!(table.players[0].is_none()); // the spot is empty now
+        assert_eq!(table.players[1].as_ref().unwrap().money, 1008);
     }
 
     /// if someone who is not the admin attempts an admin command, it does not work
     #[test]
     fn not_admin() {
-        let mut game = Game::default();
+        let mut table = Table::default();
         //let _incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         //let cloned_actions = incoming_actions.clone();
         let cloned_meta_actions = incoming_meta_actions.clone();
-	let new_blind = game.small_blind + 1;
-	assert_eq!(game.small_blind, new_blind - 1); // duh
+	let new_blind = table.small_blind + 1;
+	assert_eq!(table.small_blind, new_blind - 1); // duh
 	
         // need the id for the admin command
 	// but we do not set the game's admin
         let id = uuid::Uuid::new_v4();
 	
 	// only game's with a password (private) can be updated
-	game.password = Some("arbitrary".to_string());
+	table.password = Some("arbitrary".to_string());
 	
         incoming_meta_actions
             .lock()
@@ -3044,135 +3039,135 @@ mod tests {
             .push_back(MetaAction::Admin(id, AdminCommand::SmallBlind(new_blind)));
 
 	
-        game.handle_meta_actions(&cloned_meta_actions, true, None);
-	assert_eq!(game.small_blind, new_blind - 1); // nothing changed	
+        table.handle_meta_actions(&cloned_meta_actions, true, None);
+	assert_eq!(table.small_blind, new_blind - 1); // nothing changed	
     }
     
     /// test that the admin can change the small blind with a meta action
     #[test]
     fn admin_small_blind() {
-        let mut game = Game::default();
+        let mut table = Table::default();
         //let _incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         //let cloned_actions = incoming_actions.clone();
         let cloned_meta_actions = incoming_meta_actions.clone();
-	let new_blind = game.small_blind + 1;
-	assert_eq!(game.small_blind, new_blind - 1); // duh
+	let new_blind = table.small_blind + 1;
+	assert_eq!(table.small_blind, new_blind - 1); // duh
 	
         // need the id for the admin command
         let id = uuid::Uuid::new_v4();
-	game.admin_id = id; // set the game's admin
+	table.admin_id = id; // set the game's admin
 
 	// only game's with a password (private) can be updated
-	game.password = Some("arbitrary".to_string());
+	table.password = Some("arbitrary".to_string());
 	
         incoming_meta_actions
             .lock()
             .unwrap()
             .push_back(MetaAction::Admin(id, AdminCommand::SmallBlind(new_blind)));
-        game.handle_meta_actions(&cloned_meta_actions, true, None);
-	assert_eq!(game.small_blind, new_blind);	       
+        table.handle_meta_actions(&cloned_meta_actions, true, None);
+	assert_eq!(table.small_blind, new_blind);	       
     }
 
     /// test that admin commands do not work for a game that is private (i.e. has a password)
     #[test]
     fn admin_no_password() {
-        let mut game = Game::default();
+        let mut table = Table::default();
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         let cloned_meta_actions = incoming_meta_actions.clone();
-	let new_blind = game.small_blind + 1;
-	assert_eq!(game.small_blind, new_blind - 1); // duh
+	let new_blind = table.small_blind + 1;
+	assert_eq!(table.small_blind, new_blind - 1); // duh
 	
         // need the id for the admin command
         let id = uuid::Uuid::new_v4();
-	game.admin_id = id; // set the game's admin
+	table.admin_id = id; // set the game's admin
 
-	assert!(game.password.is_none()); // make sure no password is set
+	assert!(table.password.is_none()); // make sure no password is set
 	
         incoming_meta_actions
             .lock()
             .unwrap()
             .push_back(MetaAction::Admin(id, AdminCommand::SmallBlind(new_blind)));
-        game.handle_meta_actions(&cloned_meta_actions, true, None);
-	assert_eq!(game.small_blind, new_blind - 1); // still
+        table.handle_meta_actions(&cloned_meta_actions, true, None);
+	assert_eq!(table.small_blind, new_blind - 1); // still
     }
     
     /// test that the admin can change the big blind with a meta action
     #[test]
     fn admin_big_blind() {
-        let mut game = Game::default();
+        let mut table = Table::default();
         //let _incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         //let cloned_actions = incoming_actions.clone();
         let cloned_meta_actions = incoming_meta_actions.clone();
-	let new_blind = game.big_blind + 1;
-	assert_eq!(game.big_blind, new_blind - 1);	       
+	let new_blind = table.big_blind + 1;
+	assert_eq!(table.big_blind, new_blind - 1);	       
 	
         // need the id for the admin command
         let id = uuid::Uuid::new_v4();
-	game.admin_id = id; // set the game's admin
+	table.admin_id = id; // set the game's admin
 
 	// only game's with a password (private) can be updated
-	game.password = Some("arbitrary".to_string());
+	table.password = Some("arbitrary".to_string());
 	
         incoming_meta_actions
             .lock()
             .unwrap()
             .push_back(MetaAction::Admin(id, AdminCommand::BigBlind(new_blind)));
-        game.handle_meta_actions(&cloned_meta_actions, true, None);
-	assert_eq!(game.big_blind, new_blind);	       
+        table.handle_meta_actions(&cloned_meta_actions, true, None);
+	assert_eq!(table.big_blind, new_blind);	       
     }
 
     /// test that the admin can change the buy in with a meta action
     #[test]
     fn admin_buy_in() {
-        let mut game = Game::default();
+        let mut table = Table::default();
         //let _incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         //let cloned_actions = incoming_actions.clone();
         let cloned_meta_actions = incoming_meta_actions.clone();
-	let new_buy_in = game.buy_in + 1;
-	assert_eq!(game.buy_in, new_buy_in - 1);	       
+	let new_buy_in = table.buy_in + 1;
+	assert_eq!(table.buy_in, new_buy_in - 1);	       
 	
         // need the id for the admin command
         let id = uuid::Uuid::new_v4();
-	game.admin_id = id; // set the game's admin
+	table.admin_id = id; // set the game's admin
 
 	// only game's with a password (private) can be updated
-	game.password = Some("arbitrary".to_string());
+	table.password = Some("arbitrary".to_string());
 
         incoming_meta_actions
             .lock()
             .unwrap()
             .push_back(MetaAction::Admin(id, AdminCommand::BuyIn(new_buy_in)));
-        game.handle_meta_actions(&cloned_meta_actions, true, None);
-	assert_eq!(game.buy_in, new_buy_in);	       
+        table.handle_meta_actions(&cloned_meta_actions, true, None);
+	assert_eq!(table.buy_in, new_buy_in);	       
     }
 
     /// test that the admin can change the password in with a meta action
     #[test]
     fn admin_password() {
-        let mut game = Game::default();
+        let mut table = Table::default();
         //let _incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         //let cloned_actions = incoming_actions.clone();
         let cloned_meta_actions = incoming_meta_actions.clone();
 	let new_password = "new_password".to_string();
-	assert_ne!(game.password, Some(new_password.clone()));
+	assert_ne!(table.password, Some(new_password.clone()));
 	
         // need the id for the admin command
         let id = uuid::Uuid::new_v4();
-	game.admin_id = id; // set the game's admin
+	table.admin_id = id; // set the game's admin
 
 	// only game's with a password (private) can be updated
-	game.password = Some("arbitrary".to_string());
+	table.password = Some("arbitrary".to_string());
 	
         incoming_meta_actions
             .lock()
             .unwrap()
             .push_back(MetaAction::Admin(id, AdminCommand::SetPassword(new_password.clone())));
-        game.handle_meta_actions(&cloned_meta_actions, true, None);
-	assert_eq!(game.password, Some(new_password));	
+        table.handle_meta_actions(&cloned_meta_actions, true, None);
+	assert_eq!(table.password, Some(new_password));	
     }
 
     /// test that the admin can add and remove bots with a meta action
@@ -3180,24 +3175,24 @@ mod tests {
     /// the empty seat is at index 0
     #[test]
     fn admin_bots() {
-        let mut game = Game::default();
+        let mut table = Table::default();
         //let _incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         //let cloned_actions = incoming_actions.clone();
         let cloned_meta_actions = incoming_meta_actions.clone();
-	let new_buy_in = game.buy_in + 1;
-	assert_eq!(game.buy_in, new_buy_in - 1);	       
+	let new_buy_in = table.buy_in + 1;
+	assert_eq!(table.buy_in, new_buy_in - 1);	       
 
-        assert_eq!(game.player_ids_to_configs.len(), 0); // no player configs
-        let some_players = game.players.iter().flatten().count();
+        assert_eq!(table.player_ids_to_configs.len(), 0); // no player configs
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 0); // no players
 
         // need the id for the admin command
         let id = uuid::Uuid::new_v4();
-	game.admin_id = id; // set the game's admin
+	table.admin_id = id; // set the game's admin
 
 	// only game's with a password (private) can be updated
-	game.password = Some("arbitrary".to_string());
+	table.password = Some("arbitrary".to_string());
 	
         incoming_meta_actions
             .lock()
@@ -3211,13 +3206,13 @@ mod tests {
             .lock()
             .unwrap()
             .push_back(MetaAction::Admin(id, AdminCommand::AddBot));	    
-        game.handle_meta_actions(&cloned_meta_actions, true, None);
-        assert_eq!(game.player_ids_to_configs.len(), 3); // 3 player configs
-        let some_players = game.players.iter().flatten().count();
+        table.handle_meta_actions(&cloned_meta_actions, true, None);
+        assert_eq!(table.player_ids_to_configs.len(), 3); // 3 player configs
+        let some_players = table.players.iter().flatten().count();
         assert_eq!(some_players, 3); // 3 players
 	
 	for i in 0..3 {
-            assert!(!game.players[i].as_ref().unwrap().human_controlled); // a bot
+            assert!(!table.players[i].as_ref().unwrap().human_controlled); // a bot
 	}
 
 	// now remove a bot
@@ -3225,16 +3220,16 @@ mod tests {
             .lock()
             .unwrap()
             .push_back(MetaAction::Admin(id, AdminCommand::RemoveBot));
-        game.handle_meta_actions(&cloned_meta_actions, true, None);
-        assert_eq!(game.player_ids_to_configs.len(), 2); // 2 player configs
+        table.handle_meta_actions(&cloned_meta_actions, true, None);
+        assert_eq!(table.player_ids_to_configs.len(), 2); // 2 player configs
 	// the player_ids_to_configs mapping no longer contains the id for the bot at index 0
-	assert!(game.players[0].as_ref().is_none());
+	assert!(table.players[0].as_ref().is_none());
     }
 
-    /// test that the admin can restart the game. this brings all players to the buy_in amount of money
+    /// test that the admin can restart the table. this brings all players to the buy_in amount of money
     #[test]
     fn admin_restart() {
-        let mut game = Game::default();
+        let mut table = Table::default();
         //let _incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         //let cloned_actions = incoming_actions.clone();
@@ -3243,38 +3238,38 @@ mod tests {
         let id1 = uuid::Uuid::new_v4();
         let name1 = "1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
-        game.add_human(settings1, None).unwrap();
-        game.players[0].as_mut().unwrap().money = 500;
+        table.add_human(settings1, None).unwrap();
+        table.players[0].as_mut().unwrap().money = 500;
 
         let id2 = uuid::Uuid::new_v4();
         let name2 = "2".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
-        game.add_human(settings2, None).unwrap();
+        table.add_human(settings2, None).unwrap();
 	
         // need the id for the admin command
-	game.admin_id = id1; // set the game's admin
+	table.admin_id = id1; // set the game's admin
 
 	// only game's with a password (private) can be updated
-	game.password = Some("arbitrary".to_string());
+	table.password = Some("arbitrary".to_string());
 	
 	let new_buy_in = 4321; // arbitrary
-	game.buy_in = new_buy_in;
+	table.buy_in = new_buy_in;
 	
         incoming_meta_actions
             .lock()
             .unwrap()
             .push_back(MetaAction::Admin(id1, AdminCommand::Restart));
-        game.handle_meta_actions(&cloned_meta_actions, true, None);
+        table.handle_meta_actions(&cloned_meta_actions, true, None);
 	// check that the players have the new_buy_in amount of money
-	assert_eq!(game.players[0].as_mut().unwrap().money, new_buy_in);
-	assert_eq!(game.players[1].as_mut().unwrap().money, new_buy_in);	
+	assert_eq!(table.players[0].as_mut().unwrap().money, new_buy_in);
+	assert_eq!(table.players[1].as_mut().unwrap().money, new_buy_in);	
     }
 
     /// even if a player is_sitting_out, they still are obliged to pay the blinds as
     /// they come around.
     #[test]
     fn sitting_out_pay_blinds() {
-        let mut game = Game::default();
+        let mut table = Table::default();
         let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
         let incoming_meta_actions = Arc::new(Mutex::new(VecDeque::<MetaAction>::new()));
         let cloned_actions = incoming_actions.clone();
@@ -3284,31 +3279,31 @@ mod tests {
         let id1 = uuid::Uuid::new_v4();
         let name1 = "Human1".to_string();
         let settings1 = PlayerConfig::new(id1, Some(name1), None);
-        game.add_human(settings1, None).unwrap();
+        table.add_human(settings1, None).unwrap();
 
         // player2 will start as the small blind
         let id2 = uuid::Uuid::new_v4();
         let name2 = "Human2".to_string();
         let settings2 = PlayerConfig::new(id2, Some(name2), None);
-        game.add_human(settings2, None).unwrap();
+        table.add_human(settings2, None).unwrap();
 	
         // player3 will start as the big blind
         let id3 = uuid::Uuid::new_v4();
         let name3 = "Human3".to_string();
         let settings2 = PlayerConfig::new(id3, Some(name3), None);
-        game.add_human(settings2, None).unwrap();
+        table.add_human(settings2, None).unwrap();
 
 	// player2 is_sitting_out
-        game.players[1].as_mut().unwrap().is_sitting_out = true;
+        table.players[1].as_mut().unwrap().is_sitting_out = true;
 	// player3 is_sitting_out
-        game.players[2].as_mut().unwrap().is_sitting_out = true;
+        table.players[2].as_mut().unwrap().is_sitting_out = true;
 	
 	// confirm we have two sitting out players
-        let num_sitting_out = game.players.iter().flatten().filter(|p| p.is_sitting_out).count();
+        let num_sitting_out = table.players.iter().flatten().filter(|p| p.is_sitting_out).count();
         assert_eq!(num_sitting_out, 2);	
 
         let handler = std::thread::spawn(move || {
-            game.play_one_hand(&cloned_actions, &cloned_meta_actions);
+            table.play_one_hand(&cloned_actions, &cloned_meta_actions);
             game // return the game back
         });
 
@@ -3326,9 +3321,9 @@ mod tests {
 
 	// each sitting out player should pay their blinds and then fold,
 	// and player1 will win the blinds
-        assert_eq!(game.players[0].as_ref().unwrap().money, 1012);
-        assert_eq!(game.players[1].as_ref().unwrap().money, 996);
-        assert_eq!(game.players[1].as_ref().unwrap().money, 996);	
+        assert_eq!(table.players[0].as_ref().unwrap().money, 1012);
+        assert_eq!(table.players[1].as_ref().unwrap().money, 996);
+        assert_eq!(table.players[1].as_ref().unwrap().money, 996);	
     }
     
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ async fn index() -> impl Responder {
 async fn new_connection(
     req: HttpRequest,
     stream: web::Payload,
-    hub_addr: web::Data<Addr<hub::GameHub>>,
+    hub_addr: web::Data<Addr<hub::TableHub>>,
 ) -> Result<HttpResponse, Error> {
     log::info!("inside new_connection()");
     ws::start(
@@ -61,7 +61,7 @@ async fn reconnect(
     path: web::Path<Uuid>,
     req: HttpRequest,
     stream: web::Payload,
-    hub_addr: web::Data<Addr<hub::GameHub>>,
+    hub_addr: web::Data<Addr<hub::TableHub>>,
 ) -> Result<HttpResponse, Error> {
     let uuid = path.into_inner();
     ws::start(
@@ -88,7 +88,7 @@ async fn main() -> std::io::Result<()> {
     let app_state = Arc::new(AtomicUsize::new(0));
 
     // start main hub actor
-    let hub = hub::GameHub::new().start();
+    let hub = hub::TableHub::new().start();
 
     log::info!("starting HTTP server at http://{}:{}", args.ip, args.port);
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -63,22 +63,22 @@ impl actix::Message for ListTables {
 }
 
 #[derive(Debug)]
-pub enum JoinGameError {
+pub enum JoinTableError {
     GameIsFull,
     InvalidPassword,
     MissingPassword
 }
 
-impl fmt::Display for JoinGameError {
+impl fmt::Display for JoinTableError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            JoinGameError::GameIsFull => {
+            JoinTableError::GameIsFull => {
                 write!(f, "Game is full.",)
             }
-            JoinGameError::InvalidPassword => {
+            JoinTableError::InvalidPassword => {
                 write!(f, "Invalid password.")
             }
-            JoinGameError::MissingPassword => {
+            JoinTableError::MissingPassword => {
                 write!(f, "Password is required.")
             }
         }
@@ -101,7 +101,7 @@ pub struct Join {
 pub enum ReturnedReason {
     Left, // the player left
     HeartBeatFailed,
-    FailureToJoin(JoinGameError),
+    FailureToJoin(JoinTableError),
 }
 
 /// the game sends this message when a player config has been returned to the hub
@@ -121,7 +121,7 @@ pub struct PlayerName {
     pub name: String,
 }
 
-pub enum CreateGameError {
+pub enum CreateTableError {
     NameNotSet,
     UnableToParseJson(String),
     PlayerDoesNotExist, // cannot be found in the lobby or at a table
@@ -130,25 +130,25 @@ pub enum CreateGameError {
     TooLargeBlinds,
 }
 
-impl fmt::Display for CreateGameError {
+impl fmt::Display for CreateTableError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            CreateGameError::NameNotSet => {
+            CreateTableError::NameNotSet => {
                 write!(f, "You have not set your name")
             }
-            CreateGameError::UnableToParseJson(error_msg) => {
+            CreateTableError::UnableToParseJson(error_msg) => {
                 write!(f, "Unable to parse json: {:?}", error_msg)
 	    }
-            CreateGameError::AlreadyAtTable(table_name) => {
+            CreateTableError::AlreadyAtTable(table_name) => {
                 write!(f, "You are already at the table {}", table_name)
             }
-            CreateGameError::PlayerDoesNotExist => {
+            CreateTableError::PlayerDoesNotExist => {
                 write!(f, "The game is unaware of you. Please try refreshing your browser.")
             }
-            CreateGameError::TooManyBots => {
+            CreateTableError::TooManyBots => {
                 write!(f, "Too many bots selected")
             }
-            CreateGameError::TooLargeBlinds => {
+            CreateTableError::TooLargeBlinds => {
                 write!(f, "Blinds must be smaller than the starting stacks.")
             }
         }
@@ -167,7 +167,7 @@ pub struct CreateFields {
 
 /// Session wants to create a game
 #[derive(Message)]
-#[rtype(result = "Result<String, CreateGameError>")]
+#[rtype(result = "Result<String, CreateTableError>")]
 pub struct Create {
     /// Client ID
     pub id: Uuid,


### PR DESCRIPTION
- rename game to table across the system. to keep emphasizing where more game hand logic should live
- payouts is now settlements during the showdown. This goes in order of when a player has to show their hand (or muck). If the player currently has the best hand, they show, if not, they muck. The last aggressor (if there is one) must show first. This lets the front end actually show the winner and others' hole cards.