### PR TITLE
Min bet

### DIFF
--- a/src/logic/game_hand.rs
+++ b/src/logic/game_hand.rs
@@ -33,6 +33,7 @@ impl fmt::Display for Street {
 			
 #[derive(Debug)]
 pub struct GameHand {
+    big_blind: u32,
     pub street: Street,
     pot_manager: PotManager,
     pub street_contributions: HashMap<Street, [u32; 9]>, // how much a player contributed to the pot during each street
@@ -45,13 +46,16 @@ pub struct GameHand {
 }
 
 impl GameHand {
-    pub fn default() -> Self {
+
+    /// a new() constructor when we know the min raise upfront
+    pub fn new(big_blind: u32) -> Self {
         GameHand {
+	    big_blind,
             street: Street::Preflop,
             pot_manager: PotManager::new(),
             street_contributions: HashMap::new(),
 	    current_bet: 0,
-	    min_raise: 0,
+	    min_raise: big_blind,
             flop: None,
             turn: None,
             river: None,

--- a/src/logic/game_hand.rs
+++ b/src/logic/game_hand.rs
@@ -37,6 +37,7 @@ pub struct GameHand {
     pot_manager: PotManager,
     pub street_contributions: HashMap<Street, [u32; 9]>, // how much a player contributed to the pot during each street
     pub current_bet: u32, // the current street bet at any moment
+    pub min_raise: u32, // the minimum amount that the next raise must be
     pub flop: Option<Vec<Card>>,
     pub turn: Option<Card>,
     pub river: Option<Card>,
@@ -50,6 +51,7 @@ impl GameHand {
             pot_manager: PotManager::new(),
             street_contributions: HashMap::new(),
 	    current_bet: 0,
+	    min_raise: 0,
             flop: None,
             turn: None,
             river: None,

--- a/src/logic/pots.rs
+++ b/src/logic/pots.rs
@@ -117,7 +117,6 @@ impl PotManager {
                 }
             } else {
                 // there is not cap on this pot, so simply put the new money in for this player
-                println!("no cap");
                 *so_far += to_contribute;
                 pot.money += to_contribute;
                 if all_in {

--- a/src/logic/table.rs
+++ b/src/logic/table.rs
@@ -3343,7 +3343,7 @@ mod tests {
     /// if the BB is 8, then the next bet must be to at least 16
     /// Here, player 1 attempts a bet of 13, but is denied, and eventually times out
     #[test]
-    fn pre_flop_min_bet_fail() {
+    fn pre_flop_min_raise_fail() {
         let mut table = Table::default();
 	table.player_action_timeout = 5;
         let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
@@ -3408,7 +3408,7 @@ mod tests {
     /// Then, the SB attempts to bet 1 dollar (too low), so times out
     /// the BB folds, and the button should win the hand
     #[test]
-    fn later_street_min_bet() {
+    fn later_street_min_raise() {
         let mut table = Table::default();
 	table.player_action_timeout = 5;
         let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
@@ -3495,7 +3495,7 @@ mod tests {
     /// Player3 bets up to 45, thus setting the min raise now to be 25,
     /// Finally, Player1 attempts to bet 65, not enough (70 required), so times out
     #[test]
-    fn pre_flop_min_bet_multiple() {
+    fn pre_flop_min_raise_multiple() {
         let mut table = Table::default();
 	table.player_action_timeout = 5;
         let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
@@ -3582,7 +3582,7 @@ mod tests {
     /// min raise.
     /// Player1 will time out.
     #[test]
-    fn pre_flop_min_bet_all_in() {
+    fn pre_flop_min_raise_all_in() {
         let mut table = Table::default();
 	table.player_action_timeout = 5;
         let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));
@@ -3665,7 +3665,7 @@ mod tests {
     /// Player1 bets up to 230 (the minimum allowed)
     /// Player3 attempts to bet 270, but this is too small, so times out
     #[test]
-    fn pre_flop_min_bet_all_in2() {
+    fn pre_flop_min_raise_all_in_2() {
         let mut table = Table::default();
 	table.player_action_timeout = 5;
         let incoming_actions = Arc::new(Mutex::new(HashMap::<Uuid, PlayerAction>::new()));

--- a/src/logic/table.rs
+++ b/src/logic/table.rs
@@ -190,6 +190,7 @@ impl Table {
 	if let Some(gamehand) = gamehand_opt {
 	    state_message["street"] = gamehand.street.to_string().into();
 	    state_message["current_bet"] = gamehand.current_bet.into();
+	    state_message["min_raise"] = gamehand.min_raise.into();	    
 	    
 	    if let Some(flop) = &gamehand.flop {
 		state_message["flop"] = format!(
@@ -814,7 +815,7 @@ impl Table {
         incoming_meta_actions: &Arc<Mutex<VecDeque<MetaAction>>>,
     ) -> bool {
         println!("inside of play(). button_idx = {:?}", self.button_idx);
-        let mut gamehand = GameHand::default();
+        let mut gamehand = GameHand::new(self.big_blind);
 	let mut num_active = 0;
         for player in self.players.iter_mut().flatten() {
             if player.money == 0 {
@@ -1165,25 +1166,6 @@ impl Table {
 		// collect big blind!
 		return PlayerAction::PostBigBlind(cmp::min(self.big_blind, player.money));
             }
-
-	    let player_cumulative = gamehand.street_contributions.get(&gamehand.street).unwrap()[index];	
-	    let prompt = if gamehand.current_bet > player_cumulative {
-		let diff = gamehand.current_bet - player_cumulative;
-		format!("Enter action ({} to call): ", diff)
-	    } else {
-		format!("Enter action (current bet = {}): ", gamehand.current_bet)
-	    };
-	    let message = object! {
-		msg_type: "prompt".to_owned(),
-		prompt: prompt,
-		current_bet: gamehand.current_bet,
-		min_raise: gamehand.min_raise,
-	    };
-	    PlayerConfig::send_specific_message(
-		&message.dump(),
-		player.id,
-		&self.player_ids_to_configs,
-	    );
 	    player.id
 	};
         let mut action = None;

--- a/src/logic/table.rs
+++ b/src/logic/table.rs
@@ -884,6 +884,7 @@ impl Table {
         // the starting index is either the person one more from the button on most streets,
         // or 3 down on the preflop (since the blinds already had to buy in)
         // TODO: this needs to be smarter in small games
+	// is that ACTUALLY a todo anymore? March 26, 2023
         let mut starting_idx = self.button_idx + 1;
         if starting_idx >= self.players.len() {
             starting_idx = 0;
@@ -1295,7 +1296,6 @@ impl Table {
 				// and therefore, we are not allowed to bet!
 				// We need to check that our last action was a bet, since otherwise this
 				// is a normal situation preflop for the smallblind
-				// TODO: tell the front end about this before hand, it is a niche poker rule!
 				println!("the minimum raise was not reached on our previous bet! we cant bet");
 				let message = json::object! {
 				    msg_type: "error".to_owned(),


### PR DESCRIPTION
- the gamehand now keeps track of the min raise. It starts as the BB on each street.
- the min raise goes up to the previous raise amount.
- if a player goes all-in, then they can bet less than the min raise
- several unit test.
- the sent state now includes min_raise
- completely got rid of the prompt message to the front end